### PR TITLE
Add a GH workflow for non-flake checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,17 @@
+name: CI
+
+on: push
+
+jobs:
+  catchall:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v20
+        with:
+          extra_nix_config: |
+            extra-trusted-public-keys = cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g=
+            extra-substituters = https://cache.garnix.io
+      - uses: lriesebos/nix-develop-command@v1
+        with:
+          command: "just github-ci"

--- a/justfile
+++ b/justfile
@@ -1,14 +1,19 @@
+# Show the available commands
 list:
   just --list
 
-ci: hpack fmt test codegen check-examples
+# Check what we can before pushing changes
+pre-push: fmt github-ci check-examples
+
+# Run checks that we can’t yet run via the flake
+github-ci: test codegen
 
 fmt: fmt-nix fmt-haskell fmt-typescript
 
 check: fmt-nix-check fmt-haskell-check hpack-check fmt-typescript-check
 
 fmt-nix:
-  nixpkgs-fmt *.nix
+  nixpkgs-fmt .
 
 fmt-nix-check:
   nixpkgs-fmt --check .
@@ -55,6 +60,7 @@ hpack-check:
 test: hpack
   cabal test --test-show-details=streaming
 
+# Run the tests continuously as the code changes
 watch *args="": hpack
   #!/usr/bin/env bash
 


### PR DESCRIPTION
There are still some checks that can’t yet be done within a flake. This runs
those in a less-constrained GH workflow, so at least CI can verify them before
merging.