### PR TITLE
Work around SHA mismatches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,7 @@ jobs:
           extra_nix_config: |
             extra-trusted-public-keys = cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g=
             extra-substituters = https://cache.garnix.io
+            fallback = true
       - uses: lriesebos/nix-develop-command@v1
         with:
           command: "just github-ci"


### PR DESCRIPTION
This avoids garnix-io/issues#44 (and garnix-io/garnix#364) in our GH builds by
setting `fallback = true` in the Nix config.