### PR TITLE
Remove haskell.ts from garner data files

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -8,7 +8,6 @@ copyright: "AllRightsReserved"
 
 data-files:
   - ts/base.ts
-  - ts/haskell.ts
   - ts/runner.ts
 
 default-extensions:


### PR DESCRIPTION
haskell.ts is fetched via the fileserver, like nixpkgs.ts. It’s never loaded via
the haskell package.

base.ts is the only file that needs to be available in both places. I would also
like to remove runner.ts from the fileserver, but currently it simply serves
from the worktree.