### PR TITLE
Ignore flake.nix files for `src` in generated flake files

### DIFF
--- a/.golden/generates_formatted_flakes/golden
+++ b/.golden/generates_formatted_flakes/golden
@@ -20,7 +20,34 @@
           };
         in
         {
-          foo = (pkgs.haskell.packages.ghc94.callCabal2nix "garner-pkg" ./. { }) // { meta.mainProgram = "garner-test"; };
+          foo =
+            (pkgs.haskell.packages.ghc94.callCabal2nix
+              "garner-pkg"
+
+              (
+                let
+                  lib = pkgs.lib;
+                  lastSafe = list:
+                    if lib.lists.length list == 0
+                    then null
+                    else lib.lists.last list;
+                in
+                builtins.path
+                  {
+                    path = ./.;
+                    filter = path: type:
+                      let
+                        fileName = lastSafe (lib.strings.splitString "/" path);
+                      in
+                      fileName != "flake.nix";
+                  }
+              )
+
+              { })
+            // {
+              meta.mainProgram = "garner-test";
+            }
+          ;
         });
       devShells = forAllSystems (system:
         let

--- a/examples/frontend-create-react-app/flake.nix
+++ b/examples/frontend-create-react-app/flake.nix
@@ -32,7 +32,26 @@
             in
             npmlock2nix.v2.build
               {
-                src = ./.;
+                src =
+                  (
+                    let
+                      lib = pkgs.lib;
+                      lastSafe = list:
+                        if lib.lists.length list == 0
+                        then null
+                        else lib.lists.last list;
+                    in
+                    builtins.path
+                      {
+                        path = ./.;
+                        filter = path: type:
+                          let
+                            fileName = lastSafe (lib.strings.splitString "/" path);
+                          in
+                          fileName != "flake.nix";
+                      }
+                  )
+                ;
                 buildCommands = [ "npm run test -- --watchAll=false" "mkdir $out" ];
                 installPhase = "true";
                 node_modules_attrs = {

--- a/examples/frontend-yarn-webpack/flake.nix
+++ b/examples/frontend-yarn-webpack/flake.nix
@@ -29,7 +29,26 @@
             in
             pkgs.yarn2nix-moretea.mkYarnPackage {
               nodejs = pkgs.nodejs-18_x;
-              src = ./.;
+              src =
+                (
+                  let
+                    lib = pkgs.lib;
+                    lastSafe = list:
+                      if lib.lists.length list == 0
+                      then null
+                      else lib.lists.last list;
+                  in
+                  builtins.path
+                    {
+                      path = ./.;
+                      filter = path: type:
+                        let
+                          fileName = lastSafe (lib.strings.splitString "/" path);
+                        in
+                        fileName != "flake.nix";
+                    }
+                )
+              ;
               buildPhase = "yarn mocha";
             }
           ;

--- a/examples/haskell/flake.nix
+++ b/examples/haskell/flake.nix
@@ -20,7 +20,34 @@
           };
         in
         {
-          haskellExecutable = (pkgs.haskell.packages.ghc94.callCabal2nix "garner-pkg" ./. { }) // { meta.mainProgram = "garnerTest"; };
+          haskellExecutable =
+            (pkgs.haskell.packages.ghc94.callCabal2nix
+              "garner-pkg"
+
+              (
+                let
+                  lib = pkgs.lib;
+                  lastSafe = list:
+                    if lib.lists.length list == 0
+                    then null
+                    else lib.lists.last list;
+                in
+                builtins.path
+                  {
+                    path = ./.;
+                    filter = path: type:
+                      let
+                        fileName = lastSafe (lib.strings.splitString "/" path);
+                      in
+                      fileName != "flake.nix";
+                  }
+              )
+
+              { })
+            // {
+              meta.mainProgram = "garnerTest";
+            }
+          ;
           hello = pkgs.hello;
         });
       devShells = forAllSystems (system:

--- a/examples/npm-frontend/flake.nix
+++ b/examples/npm-frontend/flake.nix
@@ -32,7 +32,26 @@
             in
             npmlock2nix.v2.build
               {
-                src = ./.;
+                src =
+                  (
+                    let
+                      lib = pkgs.lib;
+                      lastSafe = list:
+                        if lib.lists.length list == 0
+                        then null
+                        else lib.lists.last list;
+                    in
+                    builtins.path
+                      {
+                        path = ./.;
+                        filter = path: type:
+                          let
+                            fileName = lastSafe (lib.strings.splitString "/" path);
+                          in
+                          fileName != "flake.nix";
+                      }
+                  )
+                ;
                 buildCommands = [ "" "mkdir $out" ];
                 installPhase = "true";
                 node_modules_attrs = {

--- a/ts/haskell.ts
+++ b/ts/haskell.ts
@@ -1,4 +1,5 @@
 import { mkPackage, Package } from "./base.ts";
+import { nixSource } from "./utils.ts";
 
 type MkHaskellArgs = {
   description: string;
@@ -8,7 +9,15 @@ type MkHaskellArgs = {
 };
 
 export const mkHaskell = (args: MkHaskellArgs): Package => {
-  const expression = `(pkgs.haskell.packages.${args.compiler}.callCabal2nix "garner-pkg" ./${args.src} { } ) // { meta.mainProgram = "${args.executable}"; }`;
+  const expression = `
+    (pkgs.haskell.packages.${args.compiler}.callCabal2nix
+      "garner-pkg"
+      ${nixSource(args.src)}
+      { })
+      // {
+        meta.mainProgram = "${args.executable}";
+      }
+  `;
   return mkPackage({
     expression,
     description: args.description,

--- a/ts/typescript.ts
+++ b/ts/typescript.ts
@@ -1,4 +1,5 @@
 import { Package, mkPackage } from "./base.ts";
+import { nixSource } from "./utils.ts";
 
 const nodeVersions = {
   "14": {
@@ -53,7 +54,7 @@ export const mkNpmFrontend = (args: {
       in
       npmlock2nix.v2.build
         {
-          src = ./${args.src};
+          src = ${nixSource(args.src)};
           buildCommands = [ ${JSON.stringify(args.testCommand)} "mkdir $out" ];
           installPhase = "true";
           node_modules_attrs = {
@@ -77,7 +78,7 @@ export const mkYarnFrontend = (args: {
       let pkgs = ${pkgs}; in
       pkgs.yarn2nix-moretea.mkYarnPackage {
         nodejs = ${nodejs};
-        src = ./${args.src};
+        src = ${nixSource(args.src)};
         buildPhase = ${JSON.stringify(args.testCommand)};
       }
     `,

--- a/ts/utils.ts
+++ b/ts/utils.ts
@@ -1,0 +1,18 @@
+export const nixSource = (src: string) => `
+  (let
+    lib = pkgs.lib;
+    lastSafe = list :
+      if lib.lists.length list == 0
+        then null
+        else lib.lists.last list;
+  in
+  builtins.path
+    {
+      path = ./${src};
+      filter = path: type:
+        let
+          fileName = lastSafe (lib.strings.splitString "/" path);
+        in
+         fileName != "flake.nix";
+    })
+`;


### PR DESCRIPTION
This is good for faster iteration when working on `garner`. So that we don't have to rebuild packages whenever we tweak the generated `flake.nix` file.