### PR TITLE
Mention unavailable commands too

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -49,6 +49,7 @@ default-extensions:
 dependencies:
   - base >= 4.7 && < 5
   - aeson
+  - ansi-wl-pprint
   - containers
   - directory
   - getopt-generics
@@ -86,7 +87,9 @@ tests:
       - http-client
       - lens
       - lens-aeson
+      - lens-regex-pcre
       - mockery
+      - pcre-heavy
       - silently
       - wreq
       - yaml

--- a/src/Garner.hs
+++ b/src/Garner.hs
@@ -41,13 +41,12 @@ readOptionsAndConfig env = do
   if hasGarner
     then do
       garnerConfig <- readGarnerConfig (tsRunnerFilename env)
-      options <- getWithGarnerTsOptions $ targets garnerConfig
-      pure $ WithGarnerTsOpts options garnerConfig
-    else WithoutGarnerTsOpts <$> getWithoutGarnerTsOptions
+      getOpts (WithGarnerTs garnerConfig)
+    else getOpts WithoutGarnerTs
 
 runWith :: Env -> Options -> IO ()
 runWith env (WithoutGarnerTsOpts Init) = initGarnerTs $ initFileName env
-runWith env (WithGarnerTsOpts opts garnerConfig) = do
+runWith env (WithGarnerTsOpts garnerConfig opts) = do
   writeGarnerConfig garnerConfig
   case opts of
     Gen -> pure ()

--- a/test/spec/GarnerSpec.hs
+++ b/test/spec/GarnerSpec.hs
@@ -3,11 +3,13 @@
 
 module GarnerSpec where
 
-import Control.Exception (bracket)
+import Control.Exception (bracket, catch)
 import Control.Lens (from, (<>~))
+import Control.Monad (unless)
 import qualified Data.Aeson as Aeson
 import Data.Aeson.Lens
 import Data.List (sort)
+import Data.String.Conversions (cs)
 import Data.String.Interpolate (i)
 import Data.String.Interpolate.Util (unindent)
 import Data.Vector.Generic.Lens (vector)
@@ -16,6 +18,7 @@ import Development.Shake (StdoutTrim (..), cmd)
 import Garner
 import System.Directory
 import System.Environment (withArgs)
+import System.Exit (ExitCode (..))
 import System.IO (Handle, IOMode (..), withFile)
 import qualified System.IO as Sys
 import System.IO.Silently (hCapture, hCapture_)
@@ -24,6 +27,7 @@ import Test.Hspec
 import Test.Hspec.Golden (defaultGolden)
 import Test.Mockery.Directory (inTempDirectory)
 import Test.Mockery.Environment (withModifiedEnvironment)
+import Text.Regex.PCRE.Heavy (compileM, (=~))
 
 spec :: Spec
 spec = do
@@ -31,6 +35,46 @@ spec = do
 
   around_ (withModifiedEnvironment [("NIX_CONFIG", "experimental-features =")]) $ do
     describe "garner" $ around_ inTempDirectory $ do
+      describe "--help" $ do
+        it "lists available commands" $ do
+          output <- runGarner ["--help"] "" repoDir Nothing
+          stdout output
+            `shouldMatch` unindent
+              [i|
+                Available commands:
+                  init.*
+              |]
+          writeFile "garner.ts" ""
+          output <- runGarner ["--help"] "" repoDir Nothing
+          stdout output
+            `shouldMatch` unindent
+              [i|
+                Available commands:
+                  run.*
+                  enter.*
+                  gen.*
+                  ci.*
+              |]
+        it "lists unavailable commands" $ do
+          output <- runGarner ["--help"] "" repoDir Nothing
+          stdout output
+            `shouldMatch` unindent
+              [i|
+                Unavailable commands:
+                  run
+                  enter
+                  gen
+                  ci
+              |]
+          writeFile "garner.ts" ""
+          output <- runGarner ["--help"] "" repoDir Nothing
+          stdout output
+            `shouldMatch` unindent
+              [i|
+                Unavailable commands:
+                  init
+              |]
+
       describe "run" $ do
         it "runs a simple Haskell program" $ do
           writeHaskellProject repoDir
@@ -332,8 +376,10 @@ runGarner args stdin repoDir shell = do
                     tsRunnerFilename = repoDir <> "/ts/runner.ts",
                     initFileName = repoDir <> "/ts/init.ts"
                   }
-          options <- readOptionsAndConfig env
-          runWith env options
+          let go = do
+                options <- readOptionsAndConfig env
+                runWith env options
+          go `catch` \(_ :: ExitCode) -> pure ()
   return $ ProcResult {..}
   where
     withTempFile :: (Handle -> IO a) -> IO a
@@ -362,3 +408,11 @@ shellTestCommand =
         fi
     fi
   |]
+
+shouldMatch :: HasCallStack => String -> String -> Expectation
+shouldMatch actual expected = case compileM (cs expected) [] of
+  Left err -> expectationFailure $ "invalid regex: " <> show err
+  Right regex ->
+    unless (actual =~ regex) $
+      expectationFailure $
+        "expected " <> actual <> " to match regex " <> show expected


### PR DESCRIPTION
Previously the CLI would only mention commands that were available, which was somewhat confusing. Now:

```
~/garnix/garner> garner --help                                                                                               10/03/2023 12:02:11 AM
garner - the project manager

Usage: garner COMMAND

  Develop, build, and test your projects reliably and easily

Available options:
  -h,--help                Show this help text

Available commands:
  init                     Infer a garner.ts file from the project layout

Unavailable commands:
  run
  enter
  start
  gen
  ci
```