### PR TITLE
Declare typescript type in garner sidechannel

### DIFF
--- a/src/Garner/GarnerConfig.hs
+++ b/src/Garner/GarnerConfig.hs
@@ -39,10 +39,17 @@ readGarnerConfig tsRunner = do
         import * as targets from "#{dir}/garner.ts"
         import { formatFlake } from "#{tsRunner}"
 
-        console.log(JSON.stringify({
+        type GarnerConfig = {
+          targets: Record<string, { description: string }>,
+          flakeFile: string,
+        }
+
+        const config: GarnerConfig = {
           targets,
           flakeFile: formatFlake("#{nixpkgsInput}", targets),
-        }));
+        };
+
+        console.log(JSON.stringify(config));
       |]
     hClose mainHandle
     Stdout out <- cmd "deno run --quiet --check --allow-write" mainPath


### PR DESCRIPTION
While working on changing garner types we were getting unhelpful haskell parse error messages. By declaring the type in the typescript file that is templated out we get more helpful error messages