### PR TITLE
Allow specifying golang version

### DIFF
--- a/examples/go-http-backend/flake.nix
+++ b/examples/go-http-backend/flake.nix
@@ -34,6 +34,7 @@
             gomod2nix.buildGoApplication {
               pname = "go-http-backend";
               version = "0.1";
+              go = pkgs.go_1_18;
               src =
                 (
                   let
@@ -93,6 +94,7 @@
                   gomod2nix.buildGoApplication {
                     pname = "go-http-backend";
                     version = "0.1";
+                    go = pkgs.go_1_18;
                     src =
                       (
                         let
@@ -156,6 +158,7 @@
         gomod2nix.buildGoApplication {
           pname = "go-http-backend";
           version = "0.1";
+          go = pkgs.go_1_18;
           src = 
   (let
     lib = pkgs.lib;

--- a/examples/go-http-backend/garn.ts
+++ b/examples/go-http-backend/garn.ts
@@ -4,4 +4,5 @@ export const server: garn.Project = garn.go.mkGoProject({
   description: "example backend server in go",
   moduleName: "go-http-backend",
   src: ".",
+  goVersion: "1.20",
 });

--- a/test/spec/InitSpec.hs
+++ b/test/spec/InitSpec.hs
@@ -67,6 +67,7 @@ spec = do
                       description: "My go project",
                       moduleName: "some-go-project",
                       src: ".",
+                      goVersion: "1.20",
                     });
                   |]
               )


### PR DESCRIPTION
Super quick fix for allowing the go version to be specified which I noticed when parsing the go.mod file for init.