### PR TITLE
Reload only necessary files

### DIFF
--- a/scripts/fileserver.hs
+++ b/scripts/fileserver.hs
@@ -55,7 +55,7 @@ startDenoCacheInvalidator = void $ forkIO $ do
 reload :: FilePath -> IO ()
 reload file = do
   let url = "http://localhost:8777/" <> file
-  Exit _ <- cmd "deno cache --reload" url
+  Exit _ <- cmd ("deno cache --reload=" <> url) url
   pure ()
 
 listDirectoryRecursive :: FilePath -> IO [FilePath]


### PR DESCRIPTION
Previously we were reloading much more than just the module in question.

Relevant part of `deno cache --help`:

```
  -r, --reload[=<CACHE_BLOCKLIST>...]
          Reload source code cache (recompile TypeScript)
          --reload
            Reload everything
          --reload=https://deno.land/std
            Reload only standard modules
          --reload=https://deno.land/std/fs/utils.ts,https://deno.land/std/fmt/colors.ts
            Reloads specific modules
          --reload=npm:
            Reload all npm modules
          --reload=npm:chalk
            Reload specific npm module
```