### PR TITLE
Unify npm/yarn project args

### DIFF
--- a/examples/frontend-create-react-app/garn.ts
+++ b/examples/frontend-create-react-app/garn.ts
@@ -1,6 +1,6 @@
 import * as garn from "http://localhost:8777/mod.ts";
 
-export const main = garn.javascript.mkNpmFrontend({
+export const main = garn.javascript.mkNpmProject({
   description: "frontend test app created by create-react-app",
   src: ".",
   nodeVersion: "18",

--- a/examples/frontend-yarn-webpack/garn.ts
+++ b/examples/frontend-yarn-webpack/garn.ts
@@ -1,9 +1,9 @@
 import * as garn from "http://localhost:8777/mod.ts";
 
-export const frontend = garn.javascript.mkYarnFrontend({
+export const frontend = garn.javascript.mkYarnProject({
   description: "my nice yarn project",
   src: ".",
   nodeVersion: "18",
+  startCommand: "yarn start",
   testCommand: "yarn mocha",
-  serverStartCommand: "yarn start",
 });

--- a/examples/monorepo/garn.ts
+++ b/examples/monorepo/garn.ts
@@ -6,15 +6,15 @@ export const backend = garn.go.mkGoProject({
   src: "backend",
 });
 
-export const yarnFrontend = garn.javascript.mkYarnFrontend({
+export const yarnFrontend = garn.javascript.mkYarnProject({
   description: "my nice yarn project",
   src: "frontend-yarn",
   nodeVersion: "18",
+  startCommand: "yarn start",
   testCommand: "yarn mocha",
-  serverStartCommand: "yarn start",
 });
 
-export const npmFrontend = garn.javascript.mkNpmFrontend({
+export const npmFrontend = garn.javascript.mkNpmProject({
   description: "frontend test app created by create-react-app",
   src: "frontend-npm",
   nodeVersion: "18",

--- a/examples/npm-frontend/garn.ts
+++ b/examples/npm-frontend/garn.ts
@@ -1,6 +1,6 @@
 import * as garn from "http://localhost:8777/mod.ts";
 
-export const frontend = garn.javascript.mkNpmFrontend({
+export const frontend = garn.javascript.mkNpmProject({
   src: ".",
   description: "An NPM frontend",
   nodeVersion: "18",

--- a/src/Garn/GarnConfig.hs
+++ b/src/Garn/GarnConfig.hs
@@ -76,7 +76,7 @@ checkGarnFileExists = do
 
             import * as garn from "http://localhost:8777/mod.ts";
 
-            export const frontend = garn.typescript.mkNpmFrontend({
+            export const frontend = garn.typescript.mkNpmProject({
               src: "./.",
               description: "An NPM frontend",
             });

--- a/test/spec/TestUtils.hs
+++ b/test/spec/TestUtils.hs
@@ -53,10 +53,10 @@ writeNpmFrontendProject repoDir = do
   writeFile
     "garn.ts"
     [i|
-      import { mkNpmFrontend } from "#{repoDir}/ts/javascript.ts"
+      import { mkNpmProject } from "#{repoDir}/ts/javascript.ts"
 
-      export const frontend = mkNpmFrontend({
-        description: "mkNpmFrontend-test",
+      export const frontend = mkNpmProject({
+        description: "mkNpmProject-test",
         src: ".",
         nodeVersion: "18",
         testCommand: "",

--- a/website/garn.ts
+++ b/website/garn.ts
@@ -1,6 +1,6 @@
 import * as garn from "../ts/mod.ts";
 
-export default garn.javascript.mkNpmFrontend({
+export default garn.javascript.mkNpmProject({
   description: "The garn.io website",
   nodeVersion: "18",
   src: ".",

--- a/website/src/pages/main.tsx
+++ b/website/src/pages/main.tsx
@@ -19,7 +19,7 @@ need a tool or dependency,
 it's probably here`}
 </Tooltip> &#125; from <String>"https://garn.io/ts/v0.0.1/nixpkgs.ts"</String>;<br />
         <br />
-        <Export>export</Export> <Keyword>const</Keyword> frontend = garn.javascript.mkNpmFrontend(&#123; <br />
+        <Export>export</Export> <Keyword>const</Keyword> frontend = garn.javascript.mkNpmProject(&#123; <br />
   {"  "}description: <String>"My npm app"</String>,<br />
   {"  "}<Tooltip item={<>src: <String>"frontend"</String></>}>
 {`Supports mono-repos and multiple languages.


### PR DESCRIPTION
This renames `mk{Npm,Yarn}Frontend` to `mk{Npm,Yarn}Project` and unifies the naming for startCommand/testCommand. These are all now optional and do the sane default of calling `{npm,yarn} start` and `{npm,yarn} test`