### PR TITLE
Spike use tsc for garn.ts

### DIFF
--- a/examples/go-http-backend/.garn/ts-declarations/mod.d.ts
+++ b/examples/go-http-backend/.garn/ts-declarations/mod.d.ts
@@ -1,0 +1,73 @@
+export declare type Package = {
+  tag: "package";
+  nixExpression: NixExpression;
+  description?: string;
+};
+
+export declare type NixExpression = { rawNixExpressionString: string };
+
+export declare type Check = {
+  tag: "check";
+  nixExpression: NixExpression;
+};
+
+export declare type Executable = {
+  tag: "executable";
+  description: string;
+  nixExpression: NixExpression;
+};
+
+export declare type Project = {
+  /**
+   * Returns a new Project with the provided devtools added to the default
+   * Environment.
+   */
+  withDevTools<T extends Project>(this: T, devTools: Array<Package>): T;
+  /**
+   * A tagged template literal that runs the given command inside the Project's
+   * default Environment.
+   *
+   * Example:
+   * ```typescript
+   * const myExecutable = myProject.shell`echo "hello world"`;
+   * ```
+   */
+  shell(
+    this: Project,
+    _s: TemplateStringsArray,
+    ..._args: Array<string>
+  ): Executable;
+  /**
+   * Returns a check that runs in a *pure* version of the Project's default
+   * Environment.
+   */
+  check(
+    this: Project,
+    _s: TemplateStringsArray,
+    ..._args: Array<string>
+  ): Check;
+  /**
+   * Adds a Check with the given name to the Project that runs in a *pure*
+   * version of the Project's default Environment.
+   *
+   * Example:
+   * ```typescript
+   * myProject.addCheck("noTodos")`! grep -r TODO .`
+   * ```
+   */
+  addCheck<T extends Project, Name extends string>(
+    name: Name
+  ): (
+    _s: TemplateStringsArray,
+    ..._args: Array<string>
+  ) => T & Record<Name, Check>;
+};
+
+export declare namespace go {
+  export const mkGoProject: (args: {
+    description: string;
+    moduleName: string;
+    src: string;
+    goVersion?: "1.18" | "1.19" | "1.20";
+  }) => Project & { pkg: Package; };
+}

--- a/examples/go-http-backend/.garn/tsconfig.json
+++ b/examples/go-http-backend/.garn/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "baseUrl": ".",
+    "rootDir": "..",
+    "allowImportingTsExtensions": true,
+    "paths": {
+      "http://localhost:8777/*": ["./ts-declarations/*"],
+      "https://garn.io/ts/*": ["./ts-declarations/*"]
+    }
+  },
+  "include": [
+    "../garn.ts",
+    "./ts-declarations/**/*.ts"
+  ]
+}

--- a/examples/go-http-backend/tsconfig.json
+++ b/examples/go-http-backend/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "references": [
+    { "path": "./.garn" }
+  ]
+}


### PR DESCRIPTION
This is a POC of how we could get a better user experience by using standard typescript LSP when editing `garn.ts` files. This works well for me to get editor typechecking and autocompletion using `typescript-language-server`. 

One thing that is nice about this solution is that it shouldn't affect an existing typescript repo's `tsconfig` at all since all we need to do is add a reference to our own `tsconfig.json` under `.garn` where we can have all of our conflicting rules.

The hard part here though is figuring out how to populate the `ts-declarations` dir. I think there are a few solutions here, but I don't really love any of them. Would love to see if anyone else has better ideas:
1. We could create a nix package with all of the typescript declarations going back to v0.0.1 and symlink `.garn/ts-declarations` to the nix store
2. We could package a zip of all the typescript declarations going back to v0.0.1 in the garn binary an extract it to the `.garn` dir when initializing a garn project
3. We could include a `package.json` in the `.garn` directory that when running `npm install` in there the user gets type declarations for the specified version. It is then up to the user to keep the version in package.json up to date.