### PR TITLE
Fix deno land doc parsing

### DIFF
--- a/ts/javascript.ts
+++ b/ts/javascript.ts
@@ -3,7 +3,7 @@ import { Executable } from "./executable.ts";
 import { mkPackage } from "./package.ts";
 import { mkProject, Project } from "./project.ts";
 import { nixSource } from "./internal/utils.ts";
-import { nixList, NixExpression, nixRaw, nixStrLit } from "./nix.ts";
+import { nixList, nixRaw, nixStrLit } from "./nix.ts";
 
 const nodeVersions = {
   "14": {
@@ -21,10 +21,7 @@ const nodeVersions = {
     pkg: nixRaw`pkgs.nodejs-18_x`,
     permittedInsecurePackages: nixList([]),
   },
-} satisfies Record<
-  string,
-  { pkg: NixExpression; permittedInsecurePackages: NixExpression }
->;
+};
 
 type NodeVersion = keyof typeof nodeVersions;
 


### PR DESCRIPTION
Deno land must be using an older typescript parser which does not support the `satisfies` directive. I think the best move is to just remove this for now.

Unblocks #248 as soon as this is merged and we cut the next release of the garn ts library.