### PR TITLE
Support top-level executables

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ dependencies.
 For example, with this `garn.ts` file:
 
 ```typescript
-import * as garn from "https://garn.io/ts/v0.0.8/mod.ts";
+import * as garn from "https://garn.io/ts/v0.0.9/mod.ts";
 
 export const frontend = garn.javascript.mkNpmProject({
   description: "My project frontend",
@@ -90,4 +90,4 @@ reproducible.
 ## Typescript API
 
 Documentation for the `garn` Deno library is documented
-[here](https://doc.deno.land/https://garn.io/ts/v0.0.8/mod.ts).
+[here](https://doc.deno.land/https://garn.io/ts/v0.0.9/mod.ts).

--- a/examples/frontend-create-react-app/garn.ts
+++ b/examples/frontend-create-react-app/garn.ts
@@ -6,10 +6,4 @@ export const main = garn.javascript.mkNpmProject({
   nodeVersion: "18",
 });
 
-export const start = garn.mkProject(
-  {
-    description: "start the dev server",
-    defaultExecutable: main.shell`npm install && npm start`,
-  },
-  {}
-);
+export const start = main.shell`npm install && npm start`;

--- a/examples/getting-started/garn.ts
+++ b/examples/getting-started/garn.ts
@@ -1,5 +1,5 @@
-import * as garn from "https://garn.io/ts/v0.0.8/mod.ts";
-import * as pkgs from "https://garn.io/ts/v0.0.8/nixpkgs.ts";
+import * as garn from "https://garn.io/ts/v0.0.9/mod.ts";
+import * as pkgs from "https://garn.io/ts/v0.0.9/nixpkgs.ts";
 
 export const frontend = garn.javascript.mkNpmProject({
   description: "my frontend",

--- a/examples/go-http-backend/flake.nix
+++ b/examples/go-http-backend/flake.nix
@@ -141,6 +141,75 @@
           pkgs = import "${nixpkgs}" { inherit system; };
         in
         {
+          "migrate" = {
+            "type" = "app";
+            "program" = "${
+      let
+        dev = 
+        (
+    let expr = 
+      let
+        gomod2nix = gomod2nix-repo.legacyPackages.${system};
+        gomod2nix-toml = pkgs.writeText "gomod2nix-toml" "schema = 3
+
+[mod]
+  [mod.\"github.com/gorilla/mux\"]
+    version = \"v1.8.0\"
+    hash = \"sha256-s905hpzMH9bOLue09E2JmzPXfIS4HhAlgT7g13HCwKE=\"
+";
+      in
+        gomod2nix.buildGoApplication {
+          pname = "go-http-backend";
+          version = "0.1";
+          go = pkgs.go_1_20;
+          src = 
+  (let
+    lib = pkgs.lib;
+    lastSafe = list :
+      if lib.lists.length list == 0
+        then null
+        else lib.lists.last list;
+  in
+  builtins.path
+    {
+      path = ./.;
+      name = "source";
+      filter = path: type:
+        let
+          fileName = lastSafe (lib.strings.splitString "/" path);
+        in
+         fileName != "flake.nix" &&
+         fileName != "garn.ts";
+    })
+;
+          modules = gomod2nix-toml;
+        }
+    ;
+    in
+      (if expr ? env
+        then expr.env
+        else pkgs.mkShell { inputsFrom = [ expr ]; }
+      )
+    ).overrideAttrs (finalAttrs: previousAttrs: {
+          nativeBuildInputs =
+            previousAttrs.nativeBuildInputs
+            ++
+            [pkgs.gopls];
+        })
+      ;
+        shell = "go run ./scripts/migrate.go";
+        buildPath = pkgs.runCommand "build-inputs-path" {
+          inherit (dev) buildInputs nativeBuildInputs;
+        } "echo $PATH > $out";
+      in
+      pkgs.writeScript "shell-env"  ''
+        #!${pkgs.bash}/bin/bash
+        export PATH=$(cat ${buildPath}):$PATH
+        ${dev.shellHook}
+        ${shell} "$@"
+      ''
+    }";
+          };
           "server" = {
             "type" = "app";
             "program" = "${

--- a/examples/go-http-backend/garn.ts
+++ b/examples/go-http-backend/garn.ts
@@ -6,3 +6,5 @@ export const server: garn.Project = garn.go.mkGoProject({
   src: ".",
   goVersion: "1.20",
 });
+
+export const migrate: garn.Executable = server.shell`go run ./scripts/migrate.go`;

--- a/examples/go-http-backend/scripts/migrate.go
+++ b/examples/go-http-backend/scripts/migrate.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("running migrations...")
+}

--- a/examples/monorepo/flake.nix
+++ b/examples/monorepo/flake.nix
@@ -256,7 +256,6 @@
                 [ pkgs.nodejs-18_x ];
             })
           ;
-          "startAll" = pkgs.mkShell { };
         }
       );
       apps = forAllSystems (system:

--- a/examples/npm-project/flake.nix
+++ b/examples/npm-project/flake.nix
@@ -258,7 +258,7 @@
           pkgs = import "${nixpkgs}" { inherit system; };
         in
         {
-          "project" = {
+          "run" = {
             "type" = "app";
             "program" = "${
       let

--- a/examples/npm-project/garn.ts
+++ b/examples/npm-project/garn.ts
@@ -1,6 +1,6 @@
 import * as garn from "http://localhost:8777/mod.ts";
 
-const base = garn.javascript
+export const project = garn.javascript
   .mkNpmProject({
     src: ".",
     description: "An NPM frontend",
@@ -8,7 +8,4 @@ const base = garn.javascript
   })
   .addCheck("test")`npm run test`.addCheck("tsc")`npm run tsc`;
 
-export const project = {
-  ...base,
-  defaultExecutable: base.shell`npm install ; npm run run`,
-};
+export const run = project.shell`npm install ; npm run run`;

--- a/src/Garn/Optparse.hs
+++ b/src/Garn/Optparse.hs
@@ -124,7 +124,7 @@ commandOptionsParser targets =
               target
               ( info
                   (pure (CommandOptions target targetConfig))
-                  (progDesc $ description targetConfig)
+                  (progDesc $ getDescription targetConfig)
               )
         )
         $ Map.assocs targets

--- a/src/Garn/Optparse.hs
+++ b/src/Garn/Optparse.hs
@@ -74,43 +74,33 @@ withGarnTsCommandInfo =
     ("generate", "Generate the flake.nix file and exit", const $ pure Gen),
     ("check", "Run the checks of a project", checkCommand)
   ]
+
+buildCommand :: Targets -> Parser WithGarnTsCommand
+buildCommand targets =
+  Build <$> commandOptionsParser (Map.filter isProject targets)
+
+runCommand :: Targets -> Parser WithGarnTsCommand
+runCommand targets =
+  Run <$> commandOptionsParser targets <*> argvParser
   where
-    buildCommand :: Targets -> Parser WithGarnTsCommand
-    buildCommand targets =
-      Build <$> commandOptionsParser (Map.filter isBuildable targets)
+    argvParser :: Parser [String]
+    argvParser = many $ strArgument $ metavar "...args"
 
-    runCommand :: Targets -> Parser WithGarnTsCommand
-    runCommand targets =
-      Run <$> commandOptionsParser targets <*> argvParser
+enterCommand :: Targets -> Parser WithGarnTsCommand
+enterCommand targets =
+  Enter <$> commandOptionsParser (Map.filter isProject targets)
 
-    enterCommand :: Targets -> Parser WithGarnTsCommand
-    enterCommand targets =
-      Enter <$> commandOptionsParser (Map.filter isEnterable targets)
+checkCommand :: Targets -> Parser WithGarnTsCommand
+checkCommand targets =
+  let checkCommandOptions =
+        Qualified <$> commandOptionsParser (Map.filter isProject targets)
+          <|> pure Unqualified
+   in Check <$> checkCommandOptions
 
-    checkCommand :: Targets -> Parser WithGarnTsCommand
-    checkCommand targets =
-      let checkCommandOptions =
-            Qualified <$> commandOptionsParser (Map.filter isCheckable targets)
-              <|> pure Unqualified
-       in Check <$> checkCommandOptions
-
-isBuildable :: TargetConfig -> Bool
-isBuildable = \case
+isProject :: TargetConfig -> Bool
+isProject = \case
   TargetConfigProject _ -> True
   TargetConfigExecutable _ -> False
-
-isEnterable :: TargetConfig -> Bool
-isEnterable = \case
-  TargetConfigProject _ -> True
-  TargetConfigExecutable _ -> False
-
-isCheckable :: TargetConfig -> Bool
-isCheckable = \case
-  TargetConfigProject _ -> True
-  TargetConfigExecutable _ -> False
-
-argvParser :: Parser [String]
-argvParser = many $ strArgument $ metavar "...args"
 
 withGarnTsParser :: Targets -> Parser WithGarnTsCommand
 withGarnTsParser targets =

--- a/src/Garn/Optparse.hs
+++ b/src/Garn/Optparse.hs
@@ -69,18 +69,19 @@ data WithGarnTsCommand
 withGarnTsCommandInfo :: [(String, String, Targets -> Parser WithGarnTsCommand)]
 withGarnTsCommandInfo =
   [ ("build", "Build the default executable of a project", buildCommand),
-    ("run", "Build and run the default executable of a project", withCommandOptionsAndArgv Run),
+    ("run", "Build and run the default executable of a project", runCommand),
     ("enter", "Enter the default devshell for a project", enterCommand),
     ("generate", "Generate the flake.nix file and exit", const $ pure Gen),
     ("check", "Run the checks of a project", checkCommand)
   ]
   where
-    withCommandOptionsAndArgv constructor targets =
-      constructor <$> commandOptionsParser targets <*> argvParser
-
     buildCommand :: Targets -> Parser WithGarnTsCommand
     buildCommand targets =
       Build <$> commandOptionsParser (Map.filter isBuildable targets)
+
+    runCommand :: Targets -> Parser WithGarnTsCommand
+    runCommand targets =
+      Run <$> commandOptionsParser targets <*> argvParser
 
     enterCommand :: Targets -> Parser WithGarnTsCommand
     enterCommand targets =

--- a/test/spec/ExampleSpec.hs
+++ b/test/spec/ExampleSpec.hs
@@ -116,7 +116,7 @@ spec = aroundAll_ withFileServer $ do
             runGarn args stdin repoDir Nothing
 
     it "run the main executable" $ \onTestFailureLog -> do
-      output <- runGarn' ["run", "project"] ""
+      output <- runGarn' ["run", "run"] ""
       onTestFailureLog output
       stdout output `shouldEndWith` "hello from npm-project: 3\n"
       exitCode output `shouldBe` ExitSuccess

--- a/test/spec/Garn/OptparseSpec.hs
+++ b/test/spec/Garn/OptparseSpec.hs
@@ -19,31 +19,34 @@ spec = around_ (hSilence [stderr]) $ do
 
       it "parses qualified check commands" $ do
         let targetConfig =
-              TargetConfig
-                { description = "test project",
-                  packages = [],
-                  checks = []
-                }
+              TargetConfigProject $
+                ProjectTarget
+                  { description = "test project",
+                    packages = [],
+                    checks = []
+                  }
         command <- testWithGarnTs ["check", "project"] ("project" ~> targetConfig)
         command `shouldBe` Check (Qualified (CommandOptions "project" targetConfig))
 
       it "parses unqualified check commands" $ do
         let targetConfig =
-              TargetConfig
-                { description = "test project",
-                  packages = [],
-                  checks = []
-                }
+              TargetConfigProject $
+                ProjectTarget
+                  { description = "test project",
+                    packages = [],
+                    checks = []
+                  }
         command <- testWithGarnTs ["check"] ("project" ~> targetConfig)
         command `shouldBe` Check Unqualified
 
       it "errors on non-existing targets" $ do
         let targetConfig =
-              TargetConfig
-                { description = "test project",
-                  packages = [],
-                  checks = []
-                }
+              TargetConfigProject $
+                ProjectTarget
+                  { description = "test project",
+                    packages = [],
+                    checks = []
+                  }
         testWithGarnTs ["check", "does-not-exist"] ("project" ~> targetConfig)
           `shouldThrow` (== ExitFailure 1)
 

--- a/test/spec/Garn/OptparseSpec.hs
+++ b/test/spec/Garn/OptparseSpec.hs
@@ -12,11 +12,12 @@ import Test.Hspec
 spec :: Spec
 spec = around_ (hSilence [stderr]) $ do
   describe "Garn.Optparse" $ do
-    describe "check subcommand" $ do
+    describe "generate subcommand" $ do
       it "parses generate commands" $ do
         command <- testWithGarnTs ["generate"] mempty
         command `shouldBe` Gen
 
+    describe "check subcommand" $ do
       it "parses qualified check commands" $ do
         let targetConfig =
               TargetConfigProject $
@@ -49,6 +50,29 @@ spec = around_ (hSilence [stderr]) $ do
                   }
         testWithGarnTs ["check", "does-not-exist"] ("project" ~> targetConfig)
           `shouldThrow` (== ExitFailure 1)
+
+    describe "run subcommand" $ do
+      it "parses run commands" $ do
+        let targetConfig =
+              TargetConfigProject $
+                ProjectTarget
+                  { description = "test project",
+                    packages = [],
+                    checks = []
+                  }
+        command <- testWithGarnTs ["run", "project"] ("project" ~> targetConfig)
+        command `shouldBe` Run (CommandOptions "project" targetConfig) []
+
+      it "parses run commands with additional arguments" $ do
+        let targetConfig =
+              TargetConfigProject $
+                ProjectTarget
+                  { description = "test project",
+                    packages = [],
+                    checks = []
+                  }
+        command <- testWithGarnTs ["run", "project", "more", "args"] ("project" ~> targetConfig)
+        command `shouldBe` Run (CommandOptions "project" targetConfig) ["more", "args"]
 
 testWithGarnTs :: [String] -> Targets -> IO WithGarnTsCommand
 testWithGarnTs args targets = do

--- a/test/spec/GarnSpec.hs
+++ b/test/spec/GarnSpec.hs
@@ -3,8 +3,6 @@
 
 module GarnSpec (spec) where
 
-import Control.Monad (unless)
-import Data.String.Conversions (cs)
 import Data.String.Interpolate (i)
 import Data.String.Interpolate.Util (unindent)
 import System.Directory
@@ -13,7 +11,6 @@ import Test.Hspec.Golden (defaultGolden)
 import Test.Mockery.Directory (inTempDirectory)
 import Test.Mockery.Environment (withModifiedEnvironment)
 import TestUtils
-import Text.Regex.PCRE.Heavy (compileM, (=~))
 
 spec :: Spec
 spec = do
@@ -74,11 +71,3 @@ spec = do
             _ <- runGarn ["run", "foo"] "" repoDir Nothing
             flake <- readFile "./flake.nix"
             pure $ defaultGolden "generates_formatted_flakes" flake
-
-shouldMatch :: (HasCallStack) => String -> String -> Expectation
-shouldMatch actual expected = case compileM (cs expected) [] of
-  Left err -> expectationFailure $ "invalid regex: " <> show err
-  Right regex ->
-    unless (actual =~ regex) $
-      expectationFailure $
-        "expected " <> actual <> " to match regex " <> show expected

--- a/test/spec/InitSpec.hs
+++ b/test/spec/InitSpec.hs
@@ -2,8 +2,6 @@
 
 module InitSpec where
 
-import Data.Char (isSpace)
-import Data.List (dropWhileEnd)
 import Data.String.Interpolate (i)
 import Data.String.Interpolate.Util (unindent)
 import System.Directory

--- a/test/spec/InitSpec.hs
+++ b/test/spec/InitSpec.hs
@@ -31,8 +31,8 @@ spec = do
           readFile "garn.ts"
             `shouldReturn` unindent
               [i|
-                import * as garn from "https://garn.io/ts/v0.0.8/mod.ts";
-                import * as pkgs from "https://garn.io/ts/v0.0.8/nixpkgs.ts";
+                import * as garn from "https://garn.io/ts/v0.0.9/mod.ts";
+                import * as pkgs from "https://garn.io/ts/v0.0.9/nixpkgs.ts";
 
                 export const garn = garn.haskell.mkHaskellProject({
                   description: "",
@@ -55,8 +55,8 @@ spec = do
           readFile "garn.ts"
             `shouldReturn` unindent
               [i|
-                import * as garn from "https://garn.io/ts/v0.0.8/mod.ts";
-                import * as pkgs from "https://garn.io/ts/v0.0.8/nixpkgs.ts";
+                import * as garn from "https://garn.io/ts/v0.0.9/mod.ts";
+                import * as pkgs from "https://garn.io/ts/v0.0.9/nixpkgs.ts";
 
                 export const someGoProject = garn.go.mkGoProject({
                   description: "My go project",

--- a/test/spec/RunSpec.hs
+++ b/test/spec/RunSpec.hs
@@ -134,7 +134,7 @@ spec =
             let commands = ["build", "enter", "check"]
             forM_ commands $ \command -> do
               describe command $ do
-                fit "does not show top-level executables in the help" $
+                it "does not show top-level executables in the help" $
                   onTestFailureLogger $ \onTestFailureLog -> do
                     writeFile "garn.ts" $
                       unindent

--- a/test/spec/RunSpec.hs
+++ b/test/spec/RunSpec.hs
@@ -38,13 +38,7 @@ spec =
             [i|
               import * as garn from "#{repoDir}/ts/mod.ts"
 
-              export const main = garn.mkProject(
-                {
-                  description: 'Project with an executable',
-                  defaultExecutable: garn.shell`echo foobarbaz`,
-                },
-                {},
-              );
+              export const main = garn.shell`echo foobarbaz`;
             |]
           output <- runGarn ["run", "main"] "" repoDir Nothing
           stdout output `shouldBe` "foobarbaz\n"
@@ -57,13 +51,7 @@ spec =
               import { nixRaw } from "#{repoDir}/ts/nix.ts";
 
               const myEnv = garn.mkEnvironment().withDevTools([garn.mkPackage(nixRaw`pkgs.hello`)]);
-              export const main = garn.mkProject(
-                {
-                  description: 'Project with an executable',
-                  defaultExecutable: myEnv.shell`hello`,
-                },
-                {},
-              );
+              export const main = myEnv.shell`hello`;
             |]
           output <- runGarn ["run", "main"] "" repoDir Nothing
           stdout output `shouldBe` "Hello, world!\n"
@@ -75,10 +63,7 @@ spec =
             [i|
               import * as garn from "#{repoDir}/ts/mod.ts"
 
-              export const main = garn.mkProject({
-                description: 'Project with an executable',
-                defaultExecutable: garn.shell`printf "%s,%s,%s"`,
-              }, {});
+              export const main = garn.shell`printf "%s,%s,%s"`;
             |]
           output <- runGarn ["run", "main", "foo bar", "baz"] "" repoDir Nothing
           stdout output `shouldBe` "foo bar,baz,"
@@ -104,10 +89,7 @@ spec =
             [i|
               import * as garn from "#{repoDir}/ts/mod.ts"
 
-              export const printTty = garn.mkProject({
-                description: "tty",
-                defaultExecutable: garn.shell`tty`,
-              }, {});
+              export const printTty = garn.shell`tty`;
             |]
           output <- runGarn ["run", "printTty"] "" repoDir Nothing
           stdout output `shouldStartWith` "/dev/"

--- a/test/spec/TestUtils.hs
+++ b/test/spec/TestUtils.hs
@@ -4,7 +4,9 @@ module TestUtils where
 
 import Control.Concurrent
 import Control.Exception (SomeException, bracket, catch, throwIO)
+import Control.Monad (unless)
 import qualified Data.Aeson as Aeson
+import Data.String.Conversions (cs)
 import Data.String.Interpolate
 import qualified Data.Yaml as Yaml
 import Development.Shake (StdoutTrim (..), cmd)
@@ -17,6 +19,15 @@ import qualified System.IO as Sys
 import System.IO.Silently (hCapture)
 import System.IO.Temp
 import Test.Hspec
+import Text.Regex.PCRE.Heavy (compileM, (=~))
+
+shouldMatch :: (HasCallStack) => String -> String -> Expectation
+shouldMatch actual expected = case compileM (cs expected) [] of
+  Left err -> expectationFailure $ "invalid regex: " <> show err
+  Right regex ->
+    unless (actual =~ regex) $
+      expectationFailure $
+        "expected " <> actual <> " to match regex " <> show expected
 
 writeHaskellProject :: FilePath -> IO ()
 writeHaskellProject repoDir = do

--- a/ts/internal/init.ts
+++ b/ts/internal/init.ts
@@ -2,7 +2,7 @@ import * as haskell from "../haskell.ts";
 import * as go from "../go.ts";
 import outdent from "https://deno.land/x/outdent@v0.8.0/mod.ts";
 
-const GARN_VERSION = "v0.0.8";
+const GARN_VERSION = "v0.0.9";
 
 const imports = [
   `import * as garn from "https://garn.io/ts/${GARN_VERSION}/mod.ts";`,

--- a/ts/internal/utils.ts
+++ b/ts/internal/utils.ts
@@ -55,3 +55,7 @@ export const mapValues = <T, R>(
   }
   return result;
 };
+
+export const checkExhaustiveness = (x: never): never => {
+  throw new Error(`Exhaustiveness check failed: ${x}`);
+};

--- a/ts/process_compose.ts
+++ b/ts/process_compose.ts
@@ -31,5 +31,7 @@ export const processCompose = (
     nixRaw`pkgs.writeText "process-compose.yml" (builtins.toJSON ${processComposeConfig})`
   );
 
-  return emptyEnvironment.shell`${nixRaw`pkgs.process-compose`}/bin/process-compose up -f ${configYml}`;
+  const result = emptyEnvironment.shell`${nixRaw`pkgs.process-compose`}/bin/process-compose up -f ${configYml}`;
+  result.description = `processCompose(${Object.keys(executables).join(", ")})`;
+  return result;
 };

--- a/ts/process_compose.ts
+++ b/ts/process_compose.ts
@@ -3,13 +3,14 @@ import { Executable } from "./executable.ts";
 import { mapValues } from "./internal/utils.ts";
 import { nixAttrSet, nixList, nixRaw, nixStrLit } from "./nix.ts";
 import { mkPackage } from "./package.ts";
-import { mkProject } from "./project.ts";
 
 /**
  * processCompose creates an executable project that runs all specified
  * executables simultaneously using `process-compose`.
  */
-export const processCompose = (executables: Record<string, Executable>) => {
+export const processCompose = (
+  executables: Record<string, Executable>
+): Executable => {
   const processes = nixAttrSet(
     mapValues(
       (executable) =>
@@ -30,12 +31,5 @@ export const processCompose = (executables: Record<string, Executable>) => {
     nixRaw`pkgs.writeText "process-compose.yml" (builtins.toJSON ${processComposeConfig})`
   );
 
-  return mkProject(
-    {
-      description: "",
-      defaultEnvironment: emptyEnvironment,
-      defaultExecutable: emptyEnvironment.shell`${nixRaw`pkgs.process-compose`}/bin/process-compose up -f ${configYml}`,
-    },
-    {}
-  );
+  return emptyEnvironment.shell`${nixRaw`pkgs.process-compose`}/bin/process-compose up -f ${configYml}`;
 };

--- a/website/garn.ts
+++ b/website/garn.ts
@@ -7,24 +7,10 @@ export const website = garn.javascript
     nodeVersion: "18",
     src: ".",
   })
-  .addCheck("tsc")`npm run tsc`
-  .withDevTools([
-    garn.mkPackage(nixRaw('pkgs.nodePackages.typescript-language-server')),
-  ]);
+  .addCheck("tsc")`npm run tsc`.withDevTools([
+  garn.mkPackage(nixRaw("pkgs.nodePackages.typescript-language-server")),
+]);
 
+export const dev = website.shell`npm install ; npm run dev`;
 
-const topLevelExecutable = (
-  description: string,
-  executable: garn.Executable
-): garn.Project =>
-  garn.mkProject({ description, defaultExecutable: executable }, {});
-
-export const dev = topLevelExecutable(
-  "run the website in development mode",
-  website.shell`npm install ; npm run dev`
-);
-
-export const build = topLevelExecutable(
-  "build the website",
-  website.shell`npm install ; npm run build`
-);
+export const build = website.shell`npm install ; npm run build`;

--- a/website/src/docs/getting_started.mdx
+++ b/website/src/docs/getting_started.mdx
@@ -25,8 +25,8 @@ construct projects for common stacks, but you can also define these yourself.
 Here is an example `garn.ts` file for a single node-based project:
 
 ```typescript
-import * as garn from "https://garn.io/ts/v0.0.8/mod.ts";
-import * as pkgs from "https://garn.io/ts/v0.0.8/nixpkgs.ts";
+import * as garn from "https://garn.io/ts/v0.0.9/mod.ts";
+import * as pkgs from "https://garn.io/ts/v0.0.9/nixpkgs.ts";
 
 export const frontend = garn.javascript.mkNpmProject({
   description: "my frontend",
@@ -117,4 +117,4 @@ for more info.
 ## Further reading
 
 - [garn concepts](/docs/concepts)
-- [typescript api](https://doc.deno.land/https://garn.io/ts/v0.0.8/mod.ts)
+- [typescript api](https://doc.deno.land/https://garn.io/ts/v0.0.9/mod.ts)

--- a/website/src/pages/docs.tsx
+++ b/website/src/pages/docs.tsx
@@ -20,7 +20,7 @@ export const docMenuItems: { name: string; url: string }[] = [
   ...docEntries.map(([{ name, url }]) => ({ name, url: `/docs/${url}` })),
   {
     name: "typescript api",
-    url: "https://doc.deno.land/https://garn.io/ts/v0.0.8/mod.ts",
+    url: "https://doc.deno.land/https://garn.io/ts/v0.0.9/mod.ts",
   },
 ];
 

--- a/website/src/pages/main.tsx
+++ b/website/src/pages/main.tsx
@@ -16,13 +16,13 @@ const String: React.FC = props => <span className="string">{props.children}</spa
 const Export: React.FC = props => <span className="export">{props.children}</span>;
 
 const garnTs = <pre>
-        <Keyword>import</Keyword> * as garn from <String>"https://garn.io/ts/v0.0.8/mod.ts"</String>;<br />
+        <Keyword>import</Keyword> * as garn from <String>"https://garn.io/ts/v0.0.9/mod.ts"</String>;<br />
         <Keyword>import</Keyword> * as <Tooltip item="pkgs">
 {`This is a gigantic collection
 of packages, nixpkgs. If you
 need a tool or dependency,
 it's probably here`}
-</Tooltip> from <String>"https://garn.io/ts/v0.0.8/nixpkgs.ts"</String>;<br />
+</Tooltip> from <String>"https://garn.io/ts/v0.0.9/nixpkgs.ts"</String>;<br />
         <br />
         <Export>export</Export> <Keyword>const</Keyword> frontend = garn.javascript.mkNpmProject(&#123; <br />
   {"  "}description: <String>"My npm app"</String>,<br />


### PR DESCRIPTION
This PR implements support for `garn run`ning top-level `Executables`. This was mainly motivated by the go example where it was cumbersome to add some non-default executable like `go run scripts/migrate.go`.

Fixes #254.

Possibly easier to review commit by commit.