### PR TITLE
Fix frontend-create-react-app: allow to run the dev server again

### DIFF
--- a/examples/frontend-create-react-app/flake.nix
+++ b/examples/frontend-create-react-app/flake.nix
@@ -93,7 +93,7 @@
           pkgs = import "${nixpkgs}" { inherit system; };
         in
         {
-          "main" = {
+          "start" = {
             "type" = "app";
             "program" = "${
       let
@@ -105,7 +105,7 @@
             [pkgs.nodejs-18_x];
         })
       ;
-        shell = "cd . && npm start";
+        shell = "npm install && npm start";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";

--- a/examples/frontend-create-react-app/garn.ts
+++ b/examples/frontend-create-react-app/garn.ts
@@ -5,3 +5,11 @@ export const main = garn.javascript.mkNpmProject({
   src: ".",
   nodeVersion: "18",
 });
+
+export const start = garn.mkProject(
+  {
+    description: "start the dev server",
+    defaultExecutable: main.shell`npm install && npm start`,
+  },
+  {}
+);


### PR DESCRIPTION
Through #235 we removed the support to start the dev server in this example. This also resulted in a bigger diff in the generated flake. This brings that `Executable` back and then results in a much smaller diff in the `flake.nix`.