### PR TITLE
Remove moduleName from mkGoProject

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ dependencies.
 For example, with this `garn.ts` file:
 
 ```typescript
-import * as garn from "https://garn.io/ts/v0.0.9/mod.ts";
+import * as garn from "https://garn.io/ts/v0.0.10/mod.ts";
 
 export const frontend = garn.javascript.mkNpmProject({
   description: "My project frontend",
@@ -89,4 +89,4 @@ reproducible.
 ## Typescript API
 
 Documentation for the `garn` Deno library is documented
-[here](https://doc.deno.land/https://garn.io/ts/v0.0.9/mod.ts).
+[here](https://doc.deno.land/https://garn.io/ts/v0.0.10/mod.ts).

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ export const frontend = garn.javascript.mkNpmProject({
 export const backend = garn.go.mkGoProject({
   description: "My project backend",
   src: "backend",
-  moduleName: "backend",
   goVersion: "1.20",
 });
 

--- a/examples/getting-started/garn.ts
+++ b/examples/getting-started/garn.ts
@@ -1,20 +1,24 @@
 import * as garn from "https://garn.io/ts/v0.0.9/mod.ts";
 import * as pkgs from "https://garn.io/ts/v0.0.9/nixpkgs.ts";
 
-export const frontend = garn.javascript.mkNpmProject({
-  description: "my frontend",
-  nodeVersion: "18",
-  src: "./frontend",
-}).addCheck("test")`npm test`;
+export const frontend = garn.javascript
+  .mkNpmProject({
+    description: "my frontend",
+    nodeVersion: "18",
+    src: "./frontend",
+  })
+  .addCheck("test")`npm test`;
 
 export const backend = garn.go.mkGoProject({
   description: "my backend",
-  moduleName: "backend",
   src: "./backend",
   goVersion: "1.20",
 });
 
-export const deno = garn.mkProject({
-  description: "garn configuration environment",
-  defaultEnvironment: garn.emptyEnvironment.withDevTools([pkgs.deno]),
-}, {});
+export const deno = garn.mkProject(
+  {
+    description: "garn configuration environment",
+    defaultEnvironment: garn.emptyEnvironment.withDevTools([pkgs.deno]),
+  },
+  {}
+);

--- a/examples/getting-started/garn.ts
+++ b/examples/getting-started/garn.ts
@@ -1,5 +1,5 @@
-import * as garn from "https://garn.io/ts/v0.0.9/mod.ts";
-import * as pkgs from "https://garn.io/ts/v0.0.9/nixpkgs.ts";
+import * as garn from "https://garn.io/ts/v0.0.10/mod.ts";
+import * as pkgs from "https://garn.io/ts/v0.0.10/nixpkgs.ts";
 
 export const frontend = garn.javascript
   .mkNpmProject({

--- a/examples/go-http-backend/flake.nix
+++ b/examples/go-http-backend/flake.nix
@@ -32,7 +32,7 @@
 ";
             in
             gomod2nix.buildGoApplication {
-              pname = "go-http-backend";
+              pname = "go-package";
               version = "0.1";
               go = pkgs.go_1_20;
               src =
@@ -94,7 +94,7 @@
 ";
                   in
                   gomod2nix.buildGoApplication {
-                    pname = "go-http-backend";
+                    pname = "go-package";
                     version = "0.1";
                     go = pkgs.go_1_20;
                     src =
@@ -141,6 +141,75 @@
           pkgs = import "${nixpkgs}" { inherit system; };
         in
         {
+          "dev" = {
+            "type" = "app";
+            "program" = "${
+      let
+        dev = 
+        (
+    let expr = 
+      let
+        gomod2nix = gomod2nix-repo.legacyPackages.${system};
+        gomod2nix-toml = pkgs.writeText "gomod2nix-toml" "schema = 3
+
+[mod]
+  [mod.\"github.com/gorilla/mux\"]
+    version = \"v1.8.0\"
+    hash = \"sha256-s905hpzMH9bOLue09E2JmzPXfIS4HhAlgT7g13HCwKE=\"
+";
+      in
+        gomod2nix.buildGoApplication {
+          pname = "go-package";
+          version = "0.1";
+          go = pkgs.go_1_20;
+          src = 
+  (let
+    lib = pkgs.lib;
+    lastSafe = list :
+      if lib.lists.length list == 0
+        then null
+        else lib.lists.last list;
+  in
+  builtins.path
+    {
+      path = ./.;
+      name = "source";
+      filter = path: type:
+        let
+          fileName = lastSafe (lib.strings.splitString "/" path);
+        in
+         fileName != "flake.nix" &&
+         fileName != "garn.ts";
+    })
+;
+          modules = gomod2nix-toml;
+        }
+    ;
+    in
+      (if expr ? env
+        then expr.env
+        else pkgs.mkShell { inputsFrom = [ expr ]; }
+      )
+    ).overrideAttrs (finalAttrs: previousAttrs: {
+          nativeBuildInputs =
+            previousAttrs.nativeBuildInputs
+            ++
+            [pkgs.gopls];
+        })
+      ;
+        shell = "go run ./main.go";
+        buildPath = pkgs.runCommand "build-inputs-path" {
+          inherit (dev) buildInputs nativeBuildInputs;
+        } "echo $PATH > $out";
+      in
+      pkgs.writeScript "shell-env"  ''
+        #!${pkgs.bash}/bin/bash
+        export PATH=$(cat ${buildPath}):$PATH
+        ${dev.shellHook}
+        ${shell} "$@"
+      ''
+    }";
+          };
           "migrate" = {
             "type" = "app";
             "program" = "${
@@ -159,7 +228,7 @@
 ";
       in
         gomod2nix.buildGoApplication {
-          pname = "go-http-backend";
+          pname = "go-package";
           version = "0.1";
           go = pkgs.go_1_20;
           src = 
@@ -198,61 +267,6 @@
         })
       ;
         shell = "go run ./scripts/migrate.go";
-        buildPath = pkgs.runCommand "build-inputs-path" {
-          inherit (dev) buildInputs nativeBuildInputs;
-        } "echo $PATH > $out";
-      in
-      pkgs.writeScript "shell-env"  ''
-        #!${pkgs.bash}/bin/bash
-        export PATH=$(cat ${buildPath}):$PATH
-        ${dev.shellHook}
-        ${shell} "$@"
-      ''
-    }";
-          };
-          "server" = {
-            "type" = "app";
-            "program" = "${
-      let
-        dev = pkgs.mkShell {};
-        shell = "${
-      let
-        gomod2nix = gomod2nix-repo.legacyPackages.${system};
-        gomod2nix-toml = pkgs.writeText "gomod2nix-toml" "schema = 3
-
-[mod]
-  [mod.\"github.com/gorilla/mux\"]
-    version = \"v1.8.0\"
-    hash = \"sha256-s905hpzMH9bOLue09E2JmzPXfIS4HhAlgT7g13HCwKE=\"
-";
-      in
-        gomod2nix.buildGoApplication {
-          pname = "go-http-backend";
-          version = "0.1";
-          go = pkgs.go_1_20;
-          src = 
-  (let
-    lib = pkgs.lib;
-    lastSafe = list :
-      if lib.lists.length list == 0
-        then null
-        else lib.lists.last list;
-  in
-  builtins.path
-    {
-      path = ./.;
-      name = "source";
-      filter = path: type:
-        let
-          fileName = lastSafe (lib.strings.splitString "/" path);
-        in
-         fileName != "flake.nix" &&
-         fileName != "garn.ts";
-    })
-;
-          modules = gomod2nix-toml;
-        }
-    }/bin/go-http-backend";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";

--- a/examples/go-http-backend/garn.ts
+++ b/examples/go-http-backend/garn.ts
@@ -2,9 +2,10 @@ import * as garn from "http://localhost:8777/mod.ts";
 
 export const server: garn.Project = garn.go.mkGoProject({
   description: "example backend server in go",
-  moduleName: "go-http-backend",
   src: ".",
   goVersion: "1.20",
 });
+
+export const dev = server.shell`go run ./main.go`;
 
 export const migrate: garn.Executable = server.shell`go run ./scripts/migrate.go`;

--- a/examples/monorepo/garn.ts
+++ b/examples/monorepo/garn.ts
@@ -2,17 +2,17 @@ import * as garn from "http://localhost:8777/mod.ts";
 
 export const backend = garn.go.mkGoProject({
   description: "example backend server in go",
-  moduleName: "go-http-backend",
   src: "backend",
 });
 
-export const haskell = garn.haskell
-  .mkHaskellProject({
-    description: "My haskell executable",
-    executable: "helloFromHaskell",
-    compiler: "ghc94",
-    src: "haskell",
-  });
+export const runBackend = backend.shell`cd backend && go run ./main.go`;
+
+export const haskell = garn.haskell.mkHaskellProject({
+  description: "My haskell executable",
+  executable: "helloFromHaskell",
+  compiler: "ghc94",
+  src: "haskell",
+});
 
 export const npmFrontend = garn.javascript.mkNpmProject({
   description: "frontend test app created by create-react-app",
@@ -21,7 +21,7 @@ export const npmFrontend = garn.javascript.mkNpmProject({
 });
 
 export const startAll = garn.processCompose({
-  backend: backend.defaultExecutable!,
+  backend: runBackend,
   haskell: haskell.defaultExecutable!,
   frontend: npmFrontend.shell`cd frontend-npm && npm install && npm start`,
 });

--- a/test/spec/ExampleSpec.hs
+++ b/test/spec/ExampleSpec.hs
@@ -97,7 +97,7 @@ spec = aroundAll_ withFileServer $ do
           ( cmd
               (Cwd "examples/go-http-backend")
               "cabal run garn:garn --"
-              "run server"
+              "run dev"
           )
           $ do
             body <- (^. responseBody) <$> retryGet "http://localhost:3000"

--- a/test/spec/InitSpec.hs
+++ b/test/spec/InitSpec.hs
@@ -60,7 +60,6 @@ spec = do
 
                 export const someGoProject = garn.go.mkGoProject({
                   description: "My go project",
-                  moduleName: "some-go-project",
                   src: ".",
                   goVersion: "1.20",
                 });

--- a/test/spec/InitSpec.hs
+++ b/test/spec/InitSpec.hs
@@ -31,8 +31,8 @@ spec = do
           readFile "garn.ts"
             `shouldReturn` unindent
               [i|
-                import * as garn from "https://garn.io/ts/v0.0.9/mod.ts";
-                import * as pkgs from "https://garn.io/ts/v0.0.9/nixpkgs.ts";
+                import * as garn from "https://garn.io/ts/v0.0.10/mod.ts";
+                import * as pkgs from "https://garn.io/ts/v0.0.10/nixpkgs.ts";
 
                 export const garn = garn.haskell.mkHaskellProject({
                   description: "",
@@ -55,8 +55,8 @@ spec = do
           readFile "garn.ts"
             `shouldReturn` unindent
               [i|
-                import * as garn from "https://garn.io/ts/v0.0.9/mod.ts";
-                import * as pkgs from "https://garn.io/ts/v0.0.9/nixpkgs.ts";
+                import * as garn from "https://garn.io/ts/v0.0.10/mod.ts";
+                import * as pkgs from "https://garn.io/ts/v0.0.10/nixpkgs.ts";
 
                 export const someGoProject = garn.go.mkGoProject({
                   description: "My go project",

--- a/ts/go/initializers.ts
+++ b/ts/go/initializers.ts
@@ -39,7 +39,6 @@ const goModuleInitializer: Initializer = () => {
         outdent`
           export const ${camelCase(moduleName)} = garn.go.mkGoProject({
             description: "My go project",
-            moduleName: ${JSON.stringify(moduleName)},
             src: ".",
             goVersion: ${JSON.stringify(goVersion)},
           });

--- a/ts/go/mod.ts
+++ b/ts/go/mod.ts
@@ -50,7 +50,6 @@ const GO_VERSION_TO_NIXPKG_NAME = {
  */
 export function mkGoProject(args: {
   description: string;
-  moduleName: string;
   src: string;
   goVersion?: keyof typeof GO_VERSION_TO_NIXPKG_NAME;
 }): Project & {
@@ -65,7 +64,7 @@ export function mkGoProject(args: {
         )};
       in
         gomod2nix.buildGoApplication {
-          pname = ${nixStrLit(args.moduleName)};
+          pname = "go-package";
           version = "0.1";
           go = pkgs.${nixRaw(
             GO_VERSION_TO_NIXPKG_NAME[args.goVersion ?? "1.20"]
@@ -82,7 +81,6 @@ export function mkGoProject(args: {
       defaultEnvironment: packageToEnvironment(pkg, args.src).withDevTools([
         mkPackage(nixRaw`pkgs.gopls`),
       ]),
-      defaultExecutable: shell`${pkg}/bin/${args.moduleName}`,
     },
     {
       pkg,

--- a/ts/internal/init.ts
+++ b/ts/internal/init.ts
@@ -2,7 +2,7 @@ import * as haskell from "../haskell/initializers.ts";
 import * as go from "../go/initializers.ts";
 import outdent from "https://deno.land/x/outdent@v0.8.0/mod.ts";
 
-const GARN_VERSION = "v0.0.9";
+const GARN_VERSION = "v0.0.10";
 
 const imports = [
   `import * as garn from "https://garn.io/ts/${GARN_VERSION}/mod.ts";`,

--- a/ts/internal/init.ts
+++ b/ts/internal/init.ts
@@ -40,7 +40,6 @@ if (initializedSections.length === 0) {
     // For example:
     export const myGoProject = garn.go.mkGoProject({
       description: "My go project",
-      moduleName: "server",
       src: "./my-go-project",
       goVersion: "1.20",
     });

--- a/website/src/docs/getting_started.mdx
+++ b/website/src/docs/getting_started.mdx
@@ -77,7 +77,6 @@ You can configure multiple sub-projects with different tech stacks in a single
 ```typescript
 export const backend = garn.go.mkGoProject({
   description: "my backend",
-  moduleName: "backend",
   src: "./backend",
   goVersion: "1.20",
 });

--- a/website/src/docs/getting_started.mdx
+++ b/website/src/docs/getting_started.mdx
@@ -25,8 +25,8 @@ construct projects for common stacks, but you can also define these yourself.
 Here is an example `garn.ts` file for a single node-based project:
 
 ```typescript
-import * as garn from "https://garn.io/ts/v0.0.9/mod.ts";
-import * as pkgs from "https://garn.io/ts/v0.0.9/nixpkgs.ts";
+import * as garn from "https://garn.io/ts/v0.0.10/mod.ts";
+import * as pkgs from "https://garn.io/ts/v0.0.10/nixpkgs.ts";
 
 export const frontend = garn.javascript.mkNpmProject({
   description: "my frontend",
@@ -116,4 +116,4 @@ for more info.
 ## Further reading
 
 - [garn concepts](/docs/concepts)
-- [typescript api](https://doc.deno.land/https://garn.io/ts/v0.0.9/mod.ts)
+- [typescript api](https://doc.deno.land/https://garn.io/ts/v0.0.10/mod.ts)

--- a/website/src/pages/docs.tsx
+++ b/website/src/pages/docs.tsx
@@ -20,7 +20,7 @@ export const docMenuItems: { name: string; url: string }[] = [
   ...docEntries.map(([{ name, url }]) => ({ name, url: `/docs/${url}` })),
   {
     name: "typescript api",
-    url: "https://doc.deno.land/https://garn.io/ts/v0.0.9/mod.ts",
+    url: "https://doc.deno.land/https://garn.io/ts/v0.0.10/mod.ts",
   },
 ];
 

--- a/website/src/pages/main.tsx
+++ b/website/src/pages/main.tsx
@@ -44,7 +44,6 @@ executables.
 `}
         </Tooltip> = garn.go.mkGoProject(&#123; <br />
 {"  "}description: <String>"A go server"</String>,<br />
-{"  "}moduleName: <String>"server"</String>,<br />
 {"  "}src: <String>"backend"</String>,<br />
 {"  "}goVersion: <String>"1.20"</String>,<br />
 &#125;);<br />

--- a/website/src/pages/main.tsx
+++ b/website/src/pages/main.tsx
@@ -16,13 +16,13 @@ const String: React.FC = props => <span className="string">{props.children}</spa
 const Export: React.FC = props => <span className="export">{props.children}</span>;
 
 const garnTs = <pre>
-        <Keyword>import</Keyword> * as garn from <String>"https://garn.io/ts/v0.0.9/mod.ts"</String>;<br />
+        <Keyword>import</Keyword> * as garn from <String>"https://garn.io/ts/v0.0.10/mod.ts"</String>;<br />
         <Keyword>import</Keyword> * as <Tooltip item="pkgs">
 {`This is a gigantic collection
 of packages, nixpkgs. If you
 need a tool or dependency,
 it's probably here`}
-</Tooltip> from <String>"https://garn.io/ts/v0.0.9/nixpkgs.ts"</String>;<br />
+</Tooltip> from <String>"https://garn.io/ts/v0.0.10/nixpkgs.ts"</String>;<br />
         <br />
         <Export>export</Export> <Keyword>const</Keyword> frontend = garn.javascript.mkNpmProject(&#123; <br />
   {"  "}description: <String>"My npm app"</String>,<br />


### PR DESCRIPTION
Fixes #220.

I also bumped the ts lib version, since this is a breaking change.

This means that we can't `garn run` the projects that we get from `mkGoProject`
anymore. But we have ways of providing `Executables` for that.
