### PR TITLE
Implement addExecutable

### DIFF
--- a/examples/frontend-yarn-webpack/flake.nix
+++ b/examples/frontend-yarn-webpack/flake.nix
@@ -208,6 +208,69 @@
       ''
     }";
           };
+          "frontend/startDev" = {
+            "type" = "app";
+            "program" = "${
+      let
+        dev = 
+      let
+          pkgs = 
+      import "${nixpkgs}" {
+        config.permittedInsecurePackages = [];
+        inherit system;
+      }
+    ;
+          packageJson = pkgs.lib.importJSON ./package.json;
+          yarnPackage = 
+    pkgs.yarn2nix-moretea.mkYarnPackage {
+      nodejs = pkgs.nodejs-18_x;
+      yarn = pkgs.yarn;
+      src = 
+  (let
+    lib = pkgs.lib;
+    lastSafe = list :
+      if lib.lists.length list == 0
+        then null
+        else lib.lists.last list;
+  in
+  builtins.path
+    {
+      path = ./.;
+      name = "source";
+      filter = path: type:
+        let
+          fileName = lastSafe (lib.strings.splitString "/" path);
+        in
+         fileName != "flake.nix" &&
+         fileName != "garn.ts";
+    })
+;
+      buildPhase = "yarn mocha";
+      dontStrip = true;
+    };
+          nodeModulesPath = "${yarnPackage}/libexec/${packageJson.name}/node_modules";
+      in
+        pkgs.mkShell {
+          buildInputs = [ pkgs.yarn ];
+          shellHook = "
+            export PATH=${nodeModulesPath}/.bin:\$PATH
+            export NODE_PATH=${nodeModulesPath}:\$NODE_PATH
+          ";
+        }
+    ;
+        shell = "cd . && yarn start";
+        buildPath = pkgs.runCommand "build-inputs-path" {
+          inherit (dev) buildInputs nativeBuildInputs;
+        } "echo $PATH > $out";
+      in
+      pkgs.writeScript "shell-env"  ''
+        #!${pkgs.bash}/bin/bash
+        export PATH=$(cat ${buildPath}):$PATH
+        ${dev.shellHook}
+        ${shell} "$@"
+      ''
+    }";
+          };
         }
       );
     };

--- a/examples/go-http-backend/flake.nix
+++ b/examples/go-http-backend/flake.nix
@@ -141,76 +141,7 @@
           pkgs = import "${nixpkgs}" { inherit system; };
         in
         {
-          "dev" = {
-            "type" = "app";
-            "program" = "${
-      let
-        dev = 
-        (
-    let expr = 
-      let
-        gomod2nix = gomod2nix-repo.legacyPackages.${system};
-        gomod2nix-toml = pkgs.writeText "gomod2nix-toml" "schema = 3
-
-[mod]
-  [mod.\"github.com/gorilla/mux\"]
-    version = \"v1.8.0\"
-    hash = \"sha256-s905hpzMH9bOLue09E2JmzPXfIS4HhAlgT7g13HCwKE=\"
-";
-      in
-        gomod2nix.buildGoApplication {
-          pname = "go-package";
-          version = "0.1";
-          go = pkgs.go_1_20;
-          src = 
-  (let
-    lib = pkgs.lib;
-    lastSafe = list :
-      if lib.lists.length list == 0
-        then null
-        else lib.lists.last list;
-  in
-  builtins.path
-    {
-      path = ./.;
-      name = "source";
-      filter = path: type:
-        let
-          fileName = lastSafe (lib.strings.splitString "/" path);
-        in
-         fileName != "flake.nix" &&
-         fileName != "garn.ts";
-    })
-;
-          modules = gomod2nix-toml;
-        }
-    ;
-    in
-      (if expr ? env
-        then expr.env
-        else pkgs.mkShell { inputsFrom = [ expr ]; }
-      )
-    ).overrideAttrs (finalAttrs: previousAttrs: {
-          nativeBuildInputs =
-            previousAttrs.nativeBuildInputs
-            ++
-            [pkgs.gopls];
-        })
-      ;
-        shell = "go run ./main.go";
-        buildPath = pkgs.runCommand "build-inputs-path" {
-          inherit (dev) buildInputs nativeBuildInputs;
-        } "echo $PATH > $out";
-      in
-      pkgs.writeScript "shell-env"  ''
-        #!${pkgs.bash}/bin/bash
-        export PATH=$(cat ${buildPath}):$PATH
-        ${dev.shellHook}
-        ${shell} "$@"
-      ''
-    }";
-          };
-          "migrate" = {
+          "server/migrate" = {
             "type" = "app";
             "program" = "${
       let
@@ -267,6 +198,75 @@
         })
       ;
         shell = "go run ./scripts/migrate.go";
+        buildPath = pkgs.runCommand "build-inputs-path" {
+          inherit (dev) buildInputs nativeBuildInputs;
+        } "echo $PATH > $out";
+      in
+      pkgs.writeScript "shell-env"  ''
+        #!${pkgs.bash}/bin/bash
+        export PATH=$(cat ${buildPath}):$PATH
+        ${dev.shellHook}
+        ${shell} "$@"
+      ''
+    }";
+          };
+          "server/dev" = {
+            "type" = "app";
+            "program" = "${
+      let
+        dev = 
+        (
+    let expr = 
+      let
+        gomod2nix = gomod2nix-repo.legacyPackages.${system};
+        gomod2nix-toml = pkgs.writeText "gomod2nix-toml" "schema = 3
+
+[mod]
+  [mod.\"github.com/gorilla/mux\"]
+    version = \"v1.8.0\"
+    hash = \"sha256-s905hpzMH9bOLue09E2JmzPXfIS4HhAlgT7g13HCwKE=\"
+";
+      in
+        gomod2nix.buildGoApplication {
+          pname = "go-package";
+          version = "0.1";
+          go = pkgs.go_1_20;
+          src = 
+  (let
+    lib = pkgs.lib;
+    lastSafe = list :
+      if lib.lists.length list == 0
+        then null
+        else lib.lists.last list;
+  in
+  builtins.path
+    {
+      path = ./.;
+      name = "source";
+      filter = path: type:
+        let
+          fileName = lastSafe (lib.strings.splitString "/" path);
+        in
+         fileName != "flake.nix" &&
+         fileName != "garn.ts";
+    })
+;
+          modules = gomod2nix-toml;
+        }
+    ;
+    in
+      (if expr ? env
+        then expr.env
+        else pkgs.mkShell { inputsFrom = [ expr ]; }
+      )
+    ).overrideAttrs (finalAttrs: previousAttrs: {
+          nativeBuildInputs =
+            previousAttrs.nativeBuildInputs
+            ++
+            [pkgs.gopls];
+        })
+      ;
+        shell = "go run ./main.go";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";

--- a/examples/go-http-backend/garn.ts
+++ b/examples/go-http-backend/garn.ts
@@ -4,8 +4,6 @@ export const server: garn.Project = garn.go.mkGoProject({
   description: "example backend server in go",
   src: ".",
   goVersion: "1.20",
-});
+}).addExecutable("migrate")`go run ./scripts/migrate.go`
+  .addExecutable("dev")`go run ./main.go`;
 
-export const dev = server.shell`go run ./main.go`;
-
-export const migrate: garn.Executable = server.shell`go run ./scripts/migrate.go`;

--- a/examples/npm-project/flake.lock
+++ b/examples/npm-project/flake.lock
@@ -74,17 +74,17 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1693428224,
-        "narHash": "sha256-FWUUlhYqkGEySUD0blTADRiDQ7fw+H1ikivfu88uy+w=",
+        "lastModified": 1697912416,
+        "narHash": "sha256-2MLnJ9vLbiSyfA+mYHPdN76qAOfacJw/dX/sSiYdo2o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "841889913dfd06a70ffb39f603e29e46f45f0c1a",
+        "rev": "21443a102b1a2f037d02e1d22e3e0ffdda2dbff9",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "841889913dfd06a70ffb39f603e29e46f45f0c1a",
+        "rev": "21443a102b1a2f037d02e1d22e3e0ffdda2dbff9",
         "type": "github"
       }
     },

--- a/examples/npm-project/flake.nix
+++ b/examples/npm-project/flake.nix
@@ -1,5 +1,5 @@
 {
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/841889913dfd06a70ffb39f603e29e46f45f0c1a";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/21443a102b1a2f037d02e1d22e3e0ffdda2dbff9";
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.gomod2nix-repo.url = "github:nix-community/gomod2nix?rev=f95720e89af6165c8c0aa77f180461fe786f3c21";
   inputs.npmlock2nix-repo = {

--- a/src/Garn.hs
+++ b/src/Garn.hs
@@ -48,13 +48,16 @@ runWith env (WithGarnTsOpts garnConfig opts) = do
   case opts of
     Gen -> pure ()
     Run (CommandOptions {..}) argv -> do
-      callProcess "nix" $ ["run"] <> nixArgs <> [".#" <> target, "--"] <> argv
+      callProcess "nix" $ ["run"] <> nixArgs <> [".#" <> asNixFacing target, "--"] <> argv
     Enter (CommandOptions {..}) -> do
-      hPutStrLn stderr $ "[garn] Entering " <> target <> " shell. Type 'exit' to exit."
+      hPutStrLn stderr $
+        "[garn] Entering "
+          <> asUserFacing target
+          <> " shell. Type 'exit' to exit."
       let devProc =
             ( proc
                 "nix"
-                ("develop" : nixArgs <> [".#" <> target, "--command", userShell env])
+                ("develop" : nixArgs <> [".#" <> asNixFacing target, "--command", userShell env])
             )
               { std_in = UseHandle $ stdin env,
                 std_out = Inherit,
@@ -63,7 +66,7 @@ runWith env (WithGarnTsOpts garnConfig opts) = do
       c <- withCreateProcess devProc $ \_ _ _ procHandle -> do
         waitForProcess procHandle
       when (c /= ExitSuccess) $ exitWith c
-      hPutStrLn stderr $ "[garn] Exiting " <> target <> " shell."
+      hPutStrLn stderr $ "[garn] Exiting " <> asUserFacing target <> " shell."
       pure ()
     Build (CommandOptions {targetConfig}) -> do
       case targetConfig of

--- a/src/Garn/GarnConfig.hs
+++ b/src/Garn/GarnConfig.hs
@@ -7,6 +7,7 @@ import Control.Exception (IOException, catch, throwIO)
 import Control.Monad
 import Data.Aeson
   ( FromJSON (parseJSON),
+    FromJSONKey,
     Value (Object),
     defaultOptions,
     eitherDecode,
@@ -39,7 +40,23 @@ data GarnConfig = GarnConfig
   }
   deriving (Eq, Show, Generic, FromJSON)
 
-type Targets = Map String TargetConfig
+newtype TargetName = TargetName {asNixFacing :: String}
+  deriving stock (Generic, Show, Eq, Ord)
+  deriving newtype (FromJSONKey)
+
+fromUserFacing :: String -> TargetName
+fromUserFacing = TargetName . fmap sully
+  where
+    sully '.' = '/'
+    sully x = x
+
+asUserFacing :: TargetName -> String
+asUserFacing (TargetName name) = clean <$> name
+  where
+    clean '/' = '.'
+    clean x = x
+
+type Targets = Map TargetName TargetConfig
 
 data TargetConfig
   = TargetConfigProject ProjectTarget

--- a/src/Garn/Optparse.hs
+++ b/src/Garn/Optparse.hs
@@ -123,7 +123,7 @@ withoutGarnTsParser =
       ]
 
 data CommandOptions = CommandOptions
-  { target :: String,
+  { target :: TargetName,
     targetConfig :: TargetConfig
   }
   deriving stock (Eq, Show)
@@ -134,7 +134,7 @@ commandOptionsParser targets =
     ( foldMap
         ( \(target, targetConfig) ->
             OA.command
-              target
+              (asUserFacing target)
               ( info
                   (pure (CommandOptions target targetConfig))
                   (progDesc $ getDescription targetConfig)

--- a/test/spec/ExampleSpec.hs
+++ b/test/spec/ExampleSpec.hs
@@ -97,7 +97,7 @@ spec = aroundAll_ withFileServer $ do
           ( cmd
               (Cwd "examples/go-http-backend")
               "cabal run garn:garn --"
-              "run dev"
+              "run server.dev"
           )
           $ do
             body <- (^. responseBody) <$> retryGet "http://localhost:3000"
@@ -106,7 +106,7 @@ spec = aroundAll_ withFileServer $ do
       it "allows to run a migrations executable" $
         onTestFailureLogger $ \onTestFailureLog -> do
           withCurrentDirectory "examples/go-http-backend" $ do
-            output <- runGarn ["run", "migrate"] "" repoDir Nothing
+            output <- runGarn ["run", "server.migrate"] "" repoDir Nothing
             onTestFailureLog output
             stdout output `shouldBe` "running migrations...\n"
 

--- a/test/spec/Garn/OptparseSpec.hs
+++ b/test/spec/Garn/OptparseSpec.hs
@@ -27,7 +27,7 @@ spec = around_ (hSilence [stderr]) $ do
                     checks = []
                   }
         command <- testWithGarnTs ["check", "project"] ("project" ~> targetConfig)
-        command `shouldBe` Check (Qualified (CommandOptions "project" targetConfig))
+        command `shouldBe` Check (Qualified (CommandOptions (fromUserFacing "project") targetConfig))
 
       it "parses unqualified check commands" $ do
         let targetConfig =
@@ -61,7 +61,7 @@ spec = around_ (hSilence [stderr]) $ do
                     checks = []
                   }
         command <- testWithGarnTs ["run", "project"] ("project" ~> targetConfig)
-        command `shouldBe` Run (CommandOptions "project" targetConfig) []
+        command `shouldBe` Run (CommandOptions (fromUserFacing "project") targetConfig) []
 
       it "parses run commands with additional arguments" $ do
         let targetConfig =
@@ -72,7 +72,7 @@ spec = around_ (hSilence [stderr]) $ do
                     checks = []
                   }
         command <- testWithGarnTs ["run", "project", "more", "args"] ("project" ~> targetConfig)
-        command `shouldBe` Run (CommandOptions "project" targetConfig) ["more", "args"]
+        command `shouldBe` Run (CommandOptions (fromUserFacing "project") targetConfig) ["more", "args"]
 
 testWithGarnTs :: [String] -> Targets -> IO WithGarnTsCommand
 testWithGarnTs args targets = do
@@ -81,5 +81,5 @@ testWithGarnTs args targets = do
     WithGarnTsOpts _ command -> command
     _ -> error "Expected WithGarnTsOpts"
 
-(~>) :: key -> value -> Map key value
-(~>) = Map.singleton
+(~>) :: String -> value -> Map TargetName value
+k ~> v = Map.singleton (TargetName k) v

--- a/test/spec/RunSpec.hs
+++ b/test/spec/RunSpec.hs
@@ -60,6 +60,20 @@ spec =
           stdout output `shouldBe` "Hello, world!\n"
           exitCode output `shouldBe` ExitSuccess
 
+        it "runs manually specified exeutables" $ do
+          writeFile
+            "garn.ts"
+            [i|
+              import * as garn from "#{repoDir}/ts/mod.ts"
+              export const myEnv = garn.mkProject({
+                description: "my project",
+                defaultEnvironment: garn.emptyEnvironment,
+              }, {}).addExecutable("hello")`echo Hello, world!`;
+            |]
+          output <- runGarn ["run", "myEnv/hello"] "" repoDir Nothing
+          stdout output `shouldBe` "Hello, world!\n"
+          exitCode output `shouldBe` ExitSuccess
+
         it "allows specifying argv to the executable" $ do
           writeFile
             "garn.ts"

--- a/test/spec/RunSpec.hs
+++ b/test/spec/RunSpec.hs
@@ -7,7 +7,6 @@ import Data.List (sort)
 import Data.Maybe (isJust)
 import Data.String.Interpolate (i)
 import Data.String.Interpolate.Util (unindent)
-import Development.Shake (cmd_)
 import System.Directory
 import System.Environment (lookupEnv)
 import System.Exit (ExitCode (..))
@@ -70,7 +69,7 @@ spec =
                 defaultEnvironment: garn.emptyEnvironment,
               }, {}).addExecutable("hello")`echo Hello, world!`;
             |]
-          output <- runGarn ["run", "project/hello"] "" repoDir Nothing
+          output <- runGarn ["run", "project.hello"] "" repoDir Nothing
           stdout output `shouldBe` "Hello, world!\n"
           exitCode output `shouldBe` ExitSuccess
 
@@ -90,7 +89,7 @@ spec =
                 description: "b",
               }, { b });
             |]
-          output <- runGarn ["run", "c/b/a"] "" repoDir Nothing
+          output <- runGarn ["run", "c.b.a"] "" repoDir Nothing
           stdout output `shouldBe` "executable in a\n"
           exitCode output `shouldBe` ExitSuccess
 

--- a/ts/internal/runner.ts
+++ b/ts/internal/runner.ts
@@ -178,6 +178,11 @@ const findExportables = (
     assertMayExport(name, value);
     if (isProject(value)) {
       result[name] = value;
+      const nested = findExportables(value);
+      for (const key in nested) {
+        if (key === "defaultExecutable") continue;
+        result[`${name}/${key}`] = nested[key];
+      }
     } else if (isExecutable(value)) {
       result[name] = value;
     }

--- a/ts/project.ts
+++ b/ts/project.ts
@@ -169,7 +169,10 @@ const proxyEnvironmentHelpers = (): ProjectHelpers => ({
         `'.addExecutable' can only be called on projects with a default environment`
       );
     }
-    return (s: TemplateStringsArray, ...args: Array<string>) => {
+    const templateLiteralFn = (
+      s: TemplateStringsArray,
+      ...args: Array<string>
+    ) => {
       const newExecutable = { [name]: this.shell(s, ...args) } as {
         [n in Name]: Executable;
       };
@@ -178,6 +181,13 @@ const proxyEnvironmentHelpers = (): ProjectHelpers => ({
         ...newExecutable,
       };
     };
+    markAsMayNotExport(templateLiteralFn, (exportName: string) =>
+      [
+        `${exportName} exports the return type of "addExecutable", but this is not the proper usage of addExecutable.`,
+        'Did you forget the template literal? Example usage: project.addExecutable("executable-name")`shell script to run`',
+      ].join(" ")
+    );
+    return templateLiteralFn;
   },
 
   addCheck<T extends Project, Name extends string>(this: T, name: Name) {

--- a/ts/project.ts
+++ b/ts/project.ts
@@ -96,7 +96,7 @@ export function isProject(p: unknown): p is Project {
   return hasTag(p, "project");
 }
 
-type Nestable = Environment | Package | Executable | Check;
+type Nestable = Environment | Package | Executable | Check | Project;
 
 /**
  * Creates a new `Project`.


### PR DESCRIPTION
This implements `addExecutable` on project, and allows project-nested executables to be run with `/` for now. I'm not sure if it's possible to even invoke flake apps whose name contains a `.`. I experimented with `%2e` which seems to get past one layer of parsing but fails elsewhere. In the future we'll need to do something smarter with haskell to print `.` in the help text and convert it to some other character to invoke the flake app, but for now this seems more useful than not having it.