### PR TITLE
Implement npm initializer

### DIFF
--- a/justfile
+++ b/justfile
@@ -111,7 +111,7 @@ hpack-check:
       error "package.yaml has changed, please run hpack"
 
 test-ts:
-  deno test --allow-write --allow-read --allow-run ts/**/*.ts
+  deno test --allow-write --allow-read --allow-run ts/*.test.ts ts/**/*.test.ts
 
 test *args="": hpack
   cabal run --test-show-details=streaming garn:spec -- {{ args }}

--- a/justfile
+++ b/justfile
@@ -111,7 +111,7 @@ hpack-check:
       error "package.yaml has changed, please run hpack"
 
 test-ts:
-  deno test --allow-write --allow-read --allow-run ts/*.ts
+  deno test --allow-write --allow-read --allow-run ts/**/*.ts
 
 test *args="": hpack
   cabal run --test-show-details=streaming garn:spec -- {{ args }}

--- a/ts/base.ts
+++ b/ts/base.ts
@@ -1,4 +1,6 @@
-export type Initializer = () =>
+export type Initializer = (
+  directory: string,
+) =>
   | { tag: "ShouldRun"; imports?: Array<string>; makeTarget: () => string }
   | { tag: "ShouldNotRun" }
   | { tag: "UnexpectedError"; reason: string };

--- a/ts/go/initializers.ts
+++ b/ts/go/initializers.ts
@@ -2,6 +2,7 @@ import * as fs from "https://deno.land/std@0.201.0/fs/mod.ts";
 import outdent from "https://deno.land/x/outdent@v0.8.0/mod.ts";
 import { Initializer } from "../base.ts";
 import { camelCase } from "https://deno.land/x/case@2.2.0/mod.ts";
+import { join } from "https://deno.land/std@0.201.0/path/mod.ts";
 
 function parseGoMod(goModContents: string): {
   moduleName: string;
@@ -24,13 +25,13 @@ function parseGoMod(goModContents: string): {
   throw new Error("go.mod missing module name or go version");
 }
 
-const goModuleInitializer: Initializer = () => {
-  if (!fs.existsSync("go.mod")) {
+const goModuleInitializer: Initializer = (dir) => {
+  if (!fs.existsSync(join(dir, "go.mod"))) {
     return { tag: "ShouldNotRun" };
   }
   try {
     const { goVersion, moduleName } = parseGoMod(
-      Deno.readTextFileSync("go.mod"),
+      Deno.readTextFileSync(join(dir, "go.mod")),
     );
     return {
       tag: "ShouldRun",

--- a/ts/go/initializers.ts
+++ b/ts/go/initializers.ts
@@ -24,7 +24,6 @@ function parseGoMod(goModContents: string): {
   throw new Error("go.mod missing module name or go version");
 }
 
-// Initializers
 const goModuleInitializer: Initializer = () => {
   if (!fs.existsSync("go.mod")) {
     return { tag: "ShouldNotRun" };

--- a/ts/haskell/initializers.test.ts
+++ b/ts/haskell/initializers.test.ts
@@ -1,0 +1,56 @@
+import { assertEquals } from "https://deno.land/std@0.201.0/assert/mod.ts";
+import outdent from "https://deno.land/x/outdent@v0.8.0/mod.ts";
+import { join } from "https://deno.land/std@0.201.0/path/mod.ts";
+import { mkHaskellProjectInitializer } from "./initializers.ts";
+
+Deno.test(
+  "Haskell initializer does not run when no cabal file is present",
+  () => {
+    const tempDir = Deno.makeTempDirSync();
+    const result = mkHaskellProjectInitializer(tempDir);
+    assertEquals(result.tag, "ShouldNotRun");
+  },
+);
+
+Deno.test("Haskell initializer errors if the cabal file is unparseable", () => {
+  const tempDir = Deno.makeTempDirSync();
+  Deno.writeTextFileSync(
+    join(tempDir, "foo.cabal"),
+    `
+    name: foo
+  `,
+  );
+  const result = mkHaskellProjectInitializer(tempDir);
+  assertEquals(result.tag, "UnexpectedError");
+  if (result.tag === "UnexpectedError") {
+    assertEquals(result.reason, "Found but could not parse cabal file");
+  }
+});
+
+Deno.test(
+  "Haskell initializer returns a simple string if a cabal file exists",
+  () => {
+    const tempDir = Deno.makeTempDirSync();
+    Deno.writeTextFileSync(
+      join(tempDir, "foo.cabal"),
+      `
+    name: foo
+    version: 0.0.1
+  `,
+    );
+    const result = mkHaskellProjectInitializer(tempDir);
+    assertEquals(result.tag, "ShouldRun");
+    if (result.tag === "ShouldRun") {
+      assertEquals(
+        result.makeTarget(),
+        outdent`
+          export const foo = garn.haskell.mkHaskellProject({
+            description: "",
+            executable: "",
+            compiler: "ghc94",
+            src: "."
+          })`,
+      );
+    }
+  },
+);

--- a/ts/internal/init.ts
+++ b/ts/internal/init.ts
@@ -19,7 +19,7 @@ const initializers = [
 console.error("[garn] Creating a garn.ts file");
 
 for (const init of initializers) {
-  const result = init();
+  const result = init(Deno.cwd());
   switch (result.tag) {
     case "UnexpectedError":
       console.error("[garn] " + result.reason);

--- a/ts/internal/init.ts
+++ b/ts/internal/init.ts
@@ -1,5 +1,6 @@
-import * as haskell from "../haskell/initializers.ts";
 import * as go from "../go/initializers.ts";
+import * as haskell from "../haskell/initializers.ts";
+import * as javascript from "../javascript/initializers.ts";
 import outdent from "https://deno.land/x/outdent@v0.8.0/mod.ts";
 import { GARN_TS_LIB_VERSION } from "./utils.ts";
 
@@ -9,7 +10,11 @@ const imports = [
 ];
 const initializedSections = [];
 
-const initializers = [...go.initializers, ...haskell.initializers];
+const initializers = [
+  ...go.initializers,
+  ...haskell.initializers,
+  ...javascript.initializers,
+];
 
 console.error("[garn] Creating a garn.ts file");
 

--- a/ts/internal/utils.ts
+++ b/ts/internal/utils.ts
@@ -73,15 +73,6 @@ export const writeTextFile = (
   }
 `;
 
-export type ValidJsonValue =
-  | undefined
-  | null
-  | boolean
-  | string
-  | number
-  | Array<ValidJsonValue>
-  | { [key: string]: ValidJsonValue };
-
 type Result<T> = { data: T; error?: never } | { error: Error; data?: never };
 
 export const parseJson = <T>(schema: z.Schema<T>, json: string): Result<T> => {

--- a/ts/internal/utils.ts
+++ b/ts/internal/utils.ts
@@ -71,3 +71,25 @@ export const writeTextFile = (
     text = ${nixStrLit`${text}`};
   }
 `;
+
+export type ValidJsonValue =
+  | undefined
+  | null
+  | boolean
+  | string
+  | number
+  | Array<ValidJsonValue>
+  | { [key: string]: ValidJsonValue };
+
+export const parseJson = (
+  json: string,
+): [true, ValidJsonValue] | [false, Error] => {
+  try {
+    return [true, JSON.parse(json)];
+  } catch (err) {
+    return [false, err];
+  }
+};
+
+export const isObj = (t: unknown): t is Record<string, unknown> =>
+  t != null && typeof t === "object";

--- a/ts/internal/utils.ts
+++ b/ts/internal/utils.ts
@@ -82,22 +82,18 @@ export type ValidJsonValue =
   | Array<ValidJsonValue>
   | { [key: string]: ValidJsonValue };
 
-export const parseJson = <T>(
-  schema: z.Schema<T>,
-  json: string,
-): [true, T] | [false, Error] => {
+type Result<T> = { data: T; error?: never } | { error: Error; data?: never };
+
+export const parseJson = <T>(schema: z.Schema<T>, json: string): Result<T> => {
   let parsed: unknown;
   try {
     parsed = JSON.parse(json);
-  } catch (err) {
-    return [false, err];
+  } catch (error) {
+    return { error };
   }
   const result = schema.safeParse(parsed);
   if (!result.success) {
-    return [false, result.error];
+    return { error: result.error };
   }
-  return [true, result.data];
+  return { data: result.data };
 };
-
-export const isObj = (t: unknown): t is Record<string, unknown> =>
-  t != null && typeof t === "object";

--- a/ts/javascript/initializers.test.ts
+++ b/ts/javascript/initializers.test.ts
@@ -1,0 +1,125 @@
+import {
+  assertEquals,
+  assert,
+} from "https://deno.land/std@0.201.0/assert/mod.ts";
+import outdent from "https://deno.land/x/outdent@v0.8.0/mod.ts";
+import { join } from "https://deno.land/std@0.201.0/path/mod.ts";
+import { npmInitializer } from "./initializers.ts";
+
+Deno.test(
+  "NPM initializer does not run when package.json is not present",
+  () => {
+    const tempDir = Deno.makeTempDirSync();
+    const result = npmInitializer(tempDir);
+    assertEquals(result.tag, "ShouldNotRun");
+  },
+);
+
+Deno.test(
+  "NPM initializer does not run when package-lock.json is not present but yarn.lock is present",
+  () => {
+    const tempDir = Deno.makeTempDirSync();
+    Deno.writeTextFileSync(join(tempDir, "package.json"), "{}");
+    Deno.writeTextFileSync(join(tempDir, "yarn.lock"), "");
+    const result = npmInitializer(tempDir);
+    assertEquals(result.tag, "ShouldNotRun");
+  },
+);
+
+Deno.test("NPM initializer errors if package.json is unparseable", () => {
+  const tempDir = Deno.makeTempDirSync();
+  Deno.writeTextFileSync(
+    join(tempDir, "package.json"),
+    `
+      some invalid: json
+    `,
+  );
+  const result = npmInitializer(tempDir);
+  if (result.tag !== "UnexpectedError") {
+    throw new Error("expected an UnexpectedError");
+  }
+  assert(result.reason.startsWith("Could not parse package.json"));
+});
+
+Deno.test("NPM initializer returns the code to be generated", () => {
+  const tempDir = Deno.makeTempDirSync();
+  Deno.writeTextFileSync(
+    join(tempDir, "package.json"),
+    JSON.stringify({
+      name: "somepackage",
+      description: "just some package",
+    }),
+  );
+  const result = npmInitializer(tempDir);
+  if (result.tag !== "ShouldRun") {
+    throw new Error("Expected initializer to run");
+  }
+  assertEquals(
+    result.makeTarget(),
+    outdent`
+      export const somepackage = mkNpmProject({
+        description: "just some package",
+        src: ".",
+        nodeVersion: "18",
+      })
+    `,
+  );
+});
+
+Deno.test(
+  "NPM initializer has sensible defaults if name and description are missing",
+  () => {
+    const tempDir = Deno.makeTempDirSync();
+    Deno.writeTextFileSync(join(tempDir, "package.json"), "{}");
+    const result = npmInitializer(tempDir);
+    assertEquals(result.tag, "ShouldRun");
+    if (result.tag === "ShouldRun") {
+      assertEquals(
+        result.makeTarget(),
+        outdent`
+          export const npmProject = mkNpmProject({
+            description: "An NPM project",
+            src: ".",
+            nodeVersion: "18",
+          })
+        `,
+      );
+    }
+  },
+);
+
+Deno.test(
+  "NPM initializer templates out scripts as checks and executables",
+  () => {
+    const tempDir = Deno.makeTempDirSync();
+    Deno.writeTextFileSync(
+      join(tempDir, "package.json"),
+      JSON.stringify({
+        name: "somepackage",
+        description: "just some package",
+        scripts: {
+          test: "jest",
+          start: "vite --port 3000",
+          build: "vite build",
+        },
+      }),
+    );
+    const result = npmInitializer(tempDir);
+    assertEquals(result.tag, "ShouldRun");
+    if (result.tag === "ShouldRun") {
+      assertEquals(
+        result.makeTarget(),
+        outdent`
+          export const somepackage = mkNpmProject({
+            description: "just some package",
+            src: ".",
+            nodeVersion: "18",
+          })
+            .addCheck("test")\`npm run test\`
+            .addExecutable("start")\`npm run start\`
+            .addExecutable("build")\`npm run build\`
+        `,
+      );
+    }
+  },
+);

--- a/ts/javascript/initializers.ts
+++ b/ts/javascript/initializers.ts
@@ -1,14 +1,10 @@
 import { Initializer } from "../base.ts";
 import * as fs from "https://deno.land/std@0.201.0/fs/mod.ts";
-import {
-  assertEquals,
-  assert,
-} from "https://deno.land/std@0.201.0/assert/mod.ts";
 import outdent from "https://deno.land/x/outdent@v0.8.0/mod.ts";
 import { join } from "https://deno.land/std@0.201.0/path/mod.ts";
 import { isObj, parseJson } from "../internal/utils.ts";
 
-const npmInitializer: Initializer = (dir) => {
+export const npmInitializer: Initializer = (dir) => {
   const existsPkgJson = fs.existsSync(join(dir, "package.json"));
   const existsPkgLock = fs.existsSync(join(dir, "package-lock.json"));
   const existsYarnLock = fs.existsSync(join(dir, "yarn.lock"));
@@ -58,121 +54,3 @@ const npmInitializer: Initializer = (dir) => {
 };
 
 export const initializers = [npmInitializer];
-
-Deno.test(
-  "NPM initializer does not run when package.json is not present",
-  () => {
-    const tempDir = Deno.makeTempDirSync();
-    const result = npmInitializer(tempDir);
-    assertEquals(result.tag, "ShouldNotRun");
-  },
-);
-
-Deno.test(
-  "NPM initializer does not run when package-lock.json is not present but yarn.lock is present",
-  () => {
-    const tempDir = Deno.makeTempDirSync();
-    Deno.writeTextFileSync(join(tempDir, "package.json"), "{}");
-    Deno.writeTextFileSync(join(tempDir, "yarn.lock"), "");
-    const result = npmInitializer(tempDir);
-    assertEquals(result.tag, "ShouldNotRun");
-  },
-);
-
-Deno.test("NPM initializer errors if package.json is unparseable", () => {
-  const tempDir = Deno.makeTempDirSync();
-  Deno.writeTextFileSync(
-    join(tempDir, "package.json"),
-    `
-      some invalid: json
-    `,
-  );
-  const result = npmInitializer(tempDir);
-  if (result.tag !== "UnexpectedError") {
-    throw new Error("expected an UnexpectedError");
-  }
-  assert(result.reason.startsWith("Could not parse package.json"));
-});
-
-Deno.test("NPM initializer returns the code to be generated", () => {
-  const tempDir = Deno.makeTempDirSync();
-  Deno.writeTextFileSync(
-    join(tempDir, "package.json"),
-    JSON.stringify({
-      name: "somepackage",
-      description: "just some package",
-    }),
-  );
-  const result = npmInitializer(tempDir);
-  if (result.tag !== "ShouldRun") {
-    throw new Error("Expected initializer to run");
-  }
-  assertEquals(
-    result.makeTarget(),
-    outdent`
-      export const somepackage = mkNpmProject({
-        description: "just some package",
-        src: ".",
-        nodeVersion: "18",
-      })
-    `,
-  );
-});
-
-Deno.test(
-  "NPM initializer has sensible defaults if name and description are missing",
-  () => {
-    const tempDir = Deno.makeTempDirSync();
-    Deno.writeTextFileSync(join(tempDir, "package.json"), "{}");
-    const result = npmInitializer(tempDir);
-    assertEquals(result.tag, "ShouldRun");
-    if (result.tag === "ShouldRun") {
-      assertEquals(
-        result.makeTarget(),
-        outdent`
-          export const npmProject = mkNpmProject({
-            description: "An NPM project",
-            src: ".",
-            nodeVersion: "18",
-          })
-        `,
-      );
-    }
-  },
-);
-
-Deno.test(
-  "NPM initializer templates out scripts as checks and executables",
-  () => {
-    const tempDir = Deno.makeTempDirSync();
-    Deno.writeTextFileSync(
-      join(tempDir, "package.json"),
-      JSON.stringify({
-        name: "somepackage",
-        description: "just some package",
-        scripts: {
-          test: "jest",
-          start: "vite --port 3000",
-          build: "vite build",
-        },
-      }),
-    );
-    const result = npmInitializer(tempDir);
-    assertEquals(result.tag, "ShouldRun");
-    if (result.tag === "ShouldRun") {
-      assertEquals(
-        result.makeTarget(),
-        outdent`
-          export const somepackage = mkNpmProject({
-            description: "just some package",
-            src: ".",
-            nodeVersion: "18",
-          })
-            .addCheck("test")\`npm run test\`
-            .addExecutable("start")\`npm run start\`
-            .addExecutable("build")\`npm run build\`
-        `,
-      );
-    }
-  },
-);

--- a/ts/javascript/initializers.ts
+++ b/ts/javascript/initializers.ts
@@ -18,14 +18,14 @@ export const npmInitializer: Initializer = (dir) => {
     description: z.string().optional(),
     scripts: z.record(z.string()).optional(),
   });
-  const [ok, packageJson] = parseJson(packageJsonSchema, contents);
-  if (!ok) {
+  const result = parseJson(packageJsonSchema, contents);
+  if (result.error) {
     return {
       tag: "UnexpectedError",
-      reason: `Could not parse package.json: ${packageJson.message}`,
+      reason: `Could not parse package.json: ${result.error.message}`,
     };
   }
-  const scripts = Object.keys(packageJson.scripts || {});
+  const scripts = Object.keys(result.data.scripts || {});
   const nonTestScripts = scripts.filter((name) => name !== "test");
   return {
     tag: "ShouldRun",
@@ -33,8 +33,8 @@ export const npmInitializer: Initializer = (dir) => {
     makeTarget: () =>
       [
         outdent`
-          export const ${packageJson.name || "npmProject"} = mkNpmProject({
-            description: "${packageJson.description || "An NPM project"}",
+          export const ${result.data.name || "npmProject"} = mkNpmProject({
+            description: "${result.data.description || "An NPM project"}",
             src: ".",
             nodeVersion: "18",
           })

--- a/ts/javascript/initializers.ts
+++ b/ts/javascript/initializers.ts
@@ -1,0 +1,207 @@
+import { Initializer } from "../base.ts";
+import * as fs from "https://deno.land/std@0.201.0/fs/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.201.0/assert/mod.ts";
+import outdent from "https://deno.land/x/outdent@v0.8.0/mod.ts";
+import { mapValues } from "../internal/utils.ts";
+
+const npmInitializer: Initializer = () => {
+  const existsPkgJson = fs.existsSync("package.json");
+  const existsPkgLock = fs.existsSync("package-lock.json");
+  const existsYarnLock = fs.existsSync("yarn.lock");
+  if (!existsPkgJson || (!existsPkgLock && existsYarnLock)) {
+    return { tag: "ShouldNotRun" };
+  }
+  const contents = Deno.readTextFileSync("package.json");
+  try {
+    const packageJson = JSON.parse(contents);
+    const scripts = mapValues(
+      (script: string) => script.replaceAll("`", "\\`"),
+      packageJson.scripts ?? {}
+    );
+    const testScript: string | undefined = scripts.test;
+    const otherScripts = Object.entries(scripts).filter(
+      ([name]) => name !== "test"
+    );
+    return {
+      tag: "ShouldRun",
+      imports: [],
+      makeTarget: () =>
+        [
+          outdent`
+          export const ${packageJson.name || "npmProject"} = mkNpmProject({
+            description: "${packageJson.description || "An NPM project"}",
+            src: ".",
+            nodeVersion: "18",
+          })`,
+          ...(testScript ? [`.addCheck("test")\`${testScript}\``] : []),
+          ...otherScripts.map(
+            ([name, script]) =>
+              `.addExecutable(${JSON.stringify(name)})\`${script}\``
+          ),
+        ].join("\n  "),
+    };
+  } catch (_e) {
+    return {
+      tag: "UnexpectedError",
+      reason: "Could not parse package.json",
+    };
+  }
+};
+
+export const initializers = [npmInitializer];
+
+Deno.test(
+  "NPM initializer does not run when package.json is not present",
+  () => {
+    const tempDir = Deno.makeTempDirSync();
+    Deno.chdir(tempDir);
+    const result = npmInitializer();
+    assertEquals(result.tag, "ShouldNotRun");
+  }
+);
+
+Deno.test(
+  "NPM initializer does not run when package-lock.json is not present but yarn.lock is present",
+  () => {
+    const tempDir = Deno.makeTempDirSync();
+    Deno.chdir(tempDir);
+    Deno.writeTextFileSync("./package.json", "{}");
+    Deno.writeTextFileSync("./yarn.lock", "");
+    const result = npmInitializer();
+    assertEquals(result.tag, "ShouldNotRun");
+  }
+);
+
+Deno.test("NPM initializer errors if package.json is unparseable", () => {
+  const tempDir = Deno.makeTempDirSync();
+  Deno.chdir(tempDir);
+  Deno.writeTextFileSync(
+    "./package.json",
+    `
+    name: foo
+  `
+  );
+  const result = npmInitializer();
+  assertEquals(result.tag, "UnexpectedError");
+  if (result.tag === "UnexpectedError") {
+    assertEquals(result.reason, "Could not parse package.json");
+  }
+});
+
+Deno.test("NPM initializer returns the code to be generated", () => {
+  const tempDir = Deno.makeTempDirSync();
+  Deno.chdir(tempDir);
+  Deno.writeTextFileSync(
+    "./package.json",
+    JSON.stringify({
+      name: "somepackage",
+      description: "just some package",
+    })
+  );
+  const result = npmInitializer();
+  assertEquals(result.tag, "ShouldRun");
+  if (result.tag === "ShouldRun") {
+    assertEquals(
+      result.makeTarget(),
+      outdent`
+        export const somepackage = mkNpmProject({
+          description: "just some package",
+          src: ".",
+          nodeVersion: "18",
+        })
+      `
+    );
+  }
+});
+
+Deno.test(
+  "NPM initializer has sensible defaults if name and description are missing",
+  () => {
+    const tempDir = Deno.makeTempDirSync();
+    Deno.chdir(tempDir);
+    Deno.writeTextFileSync("./package.json", "{}");
+    const result = npmInitializer();
+    assertEquals(result.tag, "ShouldRun");
+    if (result.tag === "ShouldRun") {
+      assertEquals(
+        result.makeTarget(),
+        outdent`
+          export const npmProject = mkNpmProject({
+            description: "An NPM project",
+            src: ".",
+            nodeVersion: "18",
+          })
+        `
+      );
+    }
+  }
+);
+
+Deno.test(
+  "NPM initializer templates out scripts as checks and executables",
+  () => {
+    const tempDir = Deno.makeTempDirSync();
+    Deno.chdir(tempDir);
+    Deno.writeTextFileSync(
+      "./package.json",
+      JSON.stringify({
+        name: "somepackage",
+        description: "just some package",
+        scripts: {
+          test: "jest",
+          start: "vite --port 3000",
+          build: "vite build",
+        },
+      })
+    );
+    const result = npmInitializer();
+    assertEquals(result.tag, "ShouldRun");
+    if (result.tag === "ShouldRun") {
+      assertEquals(
+        result.makeTarget(),
+        outdent`
+          export const somepackage = mkNpmProject({
+            description: "just some package",
+            src: ".",
+            nodeVersion: "18",
+          })
+            .addCheck("test")\`jest\`
+            .addExecutable("start")\`vite --port 3000\`
+            .addExecutable("build")\`vite build\`
+        `
+      );
+    }
+  }
+);
+
+Deno.test("NPM initializer escapes scripts as checks and executables", () => {
+  const tempDir = Deno.makeTempDirSync();
+  Deno.chdir(tempDir);
+  Deno.writeTextFileSync(
+    "./package.json",
+    JSON.stringify({
+      name: "somepackage",
+      description: "just some package",
+      scripts: {
+        test: "echo `echo test`",
+        start: "echo `echo start`",
+      },
+    })
+  );
+  const result = npmInitializer();
+  assertEquals(result.tag, "ShouldRun");
+  if (result.tag === "ShouldRun") {
+    assertEquals(
+      result.makeTarget(),
+      outdent`
+          export const somepackage = mkNpmProject({
+            description: "just some package",
+            src: ".",
+            nodeVersion: "18",
+          })
+            .addCheck("test")\`echo \\\`echo test\\\`\`
+            .addExecutable("start")\`echo \\\`echo start\\\`\`
+        `
+    );
+  }
+});

--- a/ts/javascript/initializers.ts
+++ b/ts/javascript/initializers.ts
@@ -1,6 +1,9 @@
 import { Initializer } from "../base.ts";
 import * as fs from "https://deno.land/std@0.201.0/fs/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.201.0/assert/mod.ts";
+import {
+  assertEquals,
+  assert,
+} from "https://deno.land/std@0.201.0/assert/mod.ts";
 import outdent from "https://deno.land/x/outdent@v0.8.0/mod.ts";
 import { join } from "https://deno.land/std@0.201.0/path/mod.ts";
 import { isObj, parseJson } from "../internal/utils.ts";
@@ -85,10 +88,10 @@ Deno.test("NPM initializer errors if package.json is unparseable", () => {
     `,
   );
   const result = npmInitializer(tempDir);
-  assertEquals(result, {
-    tag: "UnexpectedError",
-    reason: "Could not parse package.json",
-  });
+  if (result.tag !== "UnexpectedError") {
+    throw new Error("expected an UnexpectedError");
+  }
+  assert(result.reason.startsWith("Could not parse package.json"));
 });
 
 Deno.test("NPM initializer returns the code to be generated", () => {

--- a/ts/nix.test.ts
+++ b/ts/nix.test.ts
@@ -1,0 +1,25 @@
+import { assertEquals } from "https://deno.land/std@0.201.0/assert/mod.ts";
+import { nixStrLit } from "./nix.ts";
+
+Deno.test("nixStrLit correctly serializes into a nix expression", () => {
+  assertEquals(nixStrLit`foo`.rawNixExpressionString, '"foo"');
+  assertEquals(
+    nixStrLit`with ${"string"} interpolation`.rawNixExpressionString,
+    '"with string interpolation"',
+  );
+  assertEquals(
+    nixStrLit`with package ${{
+      rawNixExpressionString: "pkgs.hello",
+    }} works`.rawNixExpressionString,
+    '"with package ${pkgs.hello} works"',
+  );
+  assertEquals(
+    nixStrLit`escaped dollars in strings \${should not interpolate}`
+      .rawNixExpressionString,
+    '"escaped dollars in strings \\${should not interpolate}"',
+  );
+  assertEquals(
+    nixStrLit`"double quotes" are correctly escaped`.rawNixExpressionString,
+    '"\\"double quotes\\" are correctly escaped"',
+  );
+});

--- a/ts/nix.ts
+++ b/ts/nix.ts
@@ -1,5 +1,3 @@
-import { assertEquals } from "https://deno.land/std@0.201.0/assert/mod.ts";
-
 /**
  * A union of types that are allowed to be interpolated into the `nixStrLit`
  * template literal function. This is also used in some higher level functions, such as
@@ -168,26 +166,3 @@ export function nixStrLit(
     '"';
   return { rawNixExpressionString };
 }
-
-Deno.test("nixStrLit correctly serializes into a nix expression", () => {
-  assertEquals(nixStrLit`foo`.rawNixExpressionString, '"foo"');
-  assertEquals(
-    nixStrLit`with ${"string"} interpolation`.rawNixExpressionString,
-    '"with string interpolation"',
-  );
-  assertEquals(
-    nixStrLit`with package ${{
-      rawNixExpressionString: "pkgs.hello",
-    }} works`.rawNixExpressionString,
-    '"with package ${pkgs.hello} works"',
-  );
-  assertEquals(
-    nixStrLit`escaped dollars in strings \${should not interpolate}`
-      .rawNixExpressionString,
-    '"escaped dollars in strings \\${should not interpolate}"',
-  );
-  assertEquals(
-    nixStrLit`"double quotes" are correctly escaped`.rawNixExpressionString,
-    '"\\"double quotes\\" are correctly escaped"',
-  );
-});


### PR DESCRIPTION
This is based on #267 as I think it feels really nice to be able to call `garn init` on an npm project and have all the scripts turn into executables.

Resolves #110