### PR TITLE
Update nixpkgs (both garn's and for the generated nixpkgs.ts)

### DIFF
--- a/.golden/generates_formatted_flakes/golden
+++ b/.golden/generates_formatted_flakes/golden
@@ -1,5 +1,5 @@
 {
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/21443a102b1a2f037d02e1d22e3e0ffdda2dbff9";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/6fc7203e423bbf1c8f84cccf1c4818d097612566";
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.gomod2nix-repo.url = "github:nix-community/gomod2nix?rev=f95720e89af6165c8c0aa77f180461fe786f3c21";
   inputs.npmlock2nix-repo = {

--- a/examples/frontend-create-react-app/flake.lock
+++ b/examples/frontend-create-react-app/flake.lock
@@ -74,17 +74,17 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1697912416,
-        "narHash": "sha256-2MLnJ9vLbiSyfA+mYHPdN76qAOfacJw/dX/sSiYdo2o=",
+        "lastModified": 1698376214,
+        "narHash": "sha256-8UC0cK/cT600ug+8RVc6a1sE66+U1dfsileTo65zPCg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "21443a102b1a2f037d02e1d22e3e0ffdda2dbff9",
+        "rev": "6fc7203e423bbf1c8f84cccf1c4818d097612566",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "21443a102b1a2f037d02e1d22e3e0ffdda2dbff9",
+        "rev": "6fc7203e423bbf1c8f84cccf1c4818d097612566",
         "type": "github"
       }
     },

--- a/examples/frontend-create-react-app/flake.nix
+++ b/examples/frontend-create-react-app/flake.nix
@@ -1,5 +1,5 @@
 {
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/21443a102b1a2f037d02e1d22e3e0ffdda2dbff9";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/6fc7203e423bbf1c8f84cccf1c4818d097612566";
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.gomod2nix-repo.url = "github:nix-community/gomod2nix?rev=f95720e89af6165c8c0aa77f180461fe786f3c21";
   inputs.npmlock2nix-repo = {

--- a/examples/frontend-yarn-webpack/flake.lock
+++ b/examples/frontend-yarn-webpack/flake.lock
@@ -74,17 +74,17 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1697912416,
-        "narHash": "sha256-2MLnJ9vLbiSyfA+mYHPdN76qAOfacJw/dX/sSiYdo2o=",
+        "lastModified": 1698376214,
+        "narHash": "sha256-8UC0cK/cT600ug+8RVc6a1sE66+U1dfsileTo65zPCg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "21443a102b1a2f037d02e1d22e3e0ffdda2dbff9",
+        "rev": "6fc7203e423bbf1c8f84cccf1c4818d097612566",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "21443a102b1a2f037d02e1d22e3e0ffdda2dbff9",
+        "rev": "6fc7203e423bbf1c8f84cccf1c4818d097612566",
         "type": "github"
       }
     },

--- a/examples/frontend-yarn-webpack/flake.nix
+++ b/examples/frontend-yarn-webpack/flake.nix
@@ -1,5 +1,5 @@
 {
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/21443a102b1a2f037d02e1d22e3e0ffdda2dbff9";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/6fc7203e423bbf1c8f84cccf1c4818d097612566";
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.gomod2nix-repo.url = "github:nix-community/gomod2nix?rev=f95720e89af6165c8c0aa77f180461fe786f3c21";
   inputs.npmlock2nix-repo = {

--- a/examples/go-http-backend/flake.lock
+++ b/examples/go-http-backend/flake.lock
@@ -74,17 +74,17 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1697912416,
-        "narHash": "sha256-2MLnJ9vLbiSyfA+mYHPdN76qAOfacJw/dX/sSiYdo2o=",
+        "lastModified": 1698376214,
+        "narHash": "sha256-8UC0cK/cT600ug+8RVc6a1sE66+U1dfsileTo65zPCg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "21443a102b1a2f037d02e1d22e3e0ffdda2dbff9",
+        "rev": "6fc7203e423bbf1c8f84cccf1c4818d097612566",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "21443a102b1a2f037d02e1d22e3e0ffdda2dbff9",
+        "rev": "6fc7203e423bbf1c8f84cccf1c4818d097612566",
         "type": "github"
       }
     },

--- a/examples/go-http-backend/flake.nix
+++ b/examples/go-http-backend/flake.nix
@@ -1,5 +1,5 @@
 {
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/21443a102b1a2f037d02e1d22e3e0ffdda2dbff9";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/6fc7203e423bbf1c8f84cccf1c4818d097612566";
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.gomod2nix-repo.url = "github:nix-community/gomod2nix?rev=f95720e89af6165c8c0aa77f180461fe786f3c21";
   inputs.npmlock2nix-repo = {

--- a/examples/haskell/flake.lock
+++ b/examples/haskell/flake.lock
@@ -74,17 +74,17 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1697912416,
-        "narHash": "sha256-2MLnJ9vLbiSyfA+mYHPdN76qAOfacJw/dX/sSiYdo2o=",
+        "lastModified": 1698376214,
+        "narHash": "sha256-8UC0cK/cT600ug+8RVc6a1sE66+U1dfsileTo65zPCg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "21443a102b1a2f037d02e1d22e3e0ffdda2dbff9",
+        "rev": "6fc7203e423bbf1c8f84cccf1c4818d097612566",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "21443a102b1a2f037d02e1d22e3e0ffdda2dbff9",
+        "rev": "6fc7203e423bbf1c8f84cccf1c4818d097612566",
         "type": "github"
       }
     },

--- a/examples/haskell/flake.nix
+++ b/examples/haskell/flake.nix
@@ -1,5 +1,5 @@
 {
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/21443a102b1a2f037d02e1d22e3e0ffdda2dbff9";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/6fc7203e423bbf1c8f84cccf1c4818d097612566";
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.gomod2nix-repo.url = "github:nix-community/gomod2nix?rev=f95720e89af6165c8c0aa77f180461fe786f3c21";
   inputs.npmlock2nix-repo = {

--- a/examples/monorepo/flake.lock
+++ b/examples/monorepo/flake.lock
@@ -74,17 +74,17 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1697912416,
-        "narHash": "sha256-2MLnJ9vLbiSyfA+mYHPdN76qAOfacJw/dX/sSiYdo2o=",
+        "lastModified": 1698376214,
+        "narHash": "sha256-8UC0cK/cT600ug+8RVc6a1sE66+U1dfsileTo65zPCg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "21443a102b1a2f037d02e1d22e3e0ffdda2dbff9",
+        "rev": "6fc7203e423bbf1c8f84cccf1c4818d097612566",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "21443a102b1a2f037d02e1d22e3e0ffdda2dbff9",
+        "rev": "6fc7203e423bbf1c8f84cccf1c4818d097612566",
         "type": "github"
       }
     },

--- a/examples/monorepo/flake.nix
+++ b/examples/monorepo/flake.nix
@@ -1,5 +1,5 @@
 {
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/21443a102b1a2f037d02e1d22e3e0ffdda2dbff9";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/6fc7203e423bbf1c8f84cccf1c4818d097612566";
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.gomod2nix-repo.url = "github:nix-community/gomod2nix?rev=f95720e89af6165c8c0aa77f180461fe786f3c21";
   inputs.npmlock2nix-repo = {

--- a/examples/npm-project/flake.lock
+++ b/examples/npm-project/flake.lock
@@ -74,17 +74,17 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1697912416,
-        "narHash": "sha256-2MLnJ9vLbiSyfA+mYHPdN76qAOfacJw/dX/sSiYdo2o=",
+        "lastModified": 1698376214,
+        "narHash": "sha256-8UC0cK/cT600ug+8RVc6a1sE66+U1dfsileTo65zPCg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "21443a102b1a2f037d02e1d22e3e0ffdda2dbff9",
+        "rev": "6fc7203e423bbf1c8f84cccf1c4818d097612566",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "21443a102b1a2f037d02e1d22e3e0ffdda2dbff9",
+        "rev": "6fc7203e423bbf1c8f84cccf1c4818d097612566",
         "type": "github"
       }
     },

--- a/examples/npm-project/flake.nix
+++ b/examples/npm-project/flake.nix
@@ -1,5 +1,5 @@
 {
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/21443a102b1a2f037d02e1d22e3e0ffdda2dbff9";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/6fc7203e423bbf1c8f84cccf1c4818d097612566";
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.gomod2nix-repo.url = "github:nix-community/gomod2nix?rev=f95720e89af6165c8c0aa77f180461fe786f3c21";
   inputs.npmlock2nix-repo = {

--- a/flake.lock
+++ b/flake.lock
@@ -139,16 +139,17 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1685974944,
-        "narHash": "sha256-igVt9dGBgsiZIC8yjf3Tlot6sx7hr4FyrXqnT3ZGAuA=",
+        "lastModified": 1698376214,
+        "narHash": "sha256-8UC0cK/cT600ug+8RVc6a1sE66+U1dfsileTo65zPCg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a2c62404a0842bf647607bcae827ea2f25e29d19",
+        "rev": "6fc7203e423bbf1c8f84cccf1c4818d097612566",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
+        "rev": "6fc7203e423bbf1c8f84cccf1c4818d097612566",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs.flake-utils.url = "github:numtide/flake-utils";
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/6fc7203e423bbf1c8f84cccf1c4818d097612566";
   inputs.fhi.url = "github:soenkehahn/format-haskell-interpolate";
   inputs.nix-tool-installer.url = "github:garnix-io/nix-tool-installer";
   inputs.call-flake.url = "github:divnix/call-flake";
@@ -14,7 +14,7 @@
         };
         strings = pkgs.lib.strings;
         lists = pkgs.lib.lists;
-        ourHaskell = pkgs.haskell.packages.ghc945;
+        ourHaskell = pkgs.haskell.packages.ghc947;
         websiteFlake = call-flake ./website;
         websitePackages =
           if system == "x86_64-linux" then
@@ -162,7 +162,7 @@
                 self.packages.${system}.garnHaskellPackage.buildInputs))
               (haskell-language-server.override {
                 dynamic = true;
-                supportedGhcVersions = [ "945" ];
+                supportedGhcVersions = [ "947" ];
               })
               ourHaskell.cabal2nix
               fhi.packages.${system}.default

--- a/src/Garn/Common.hs
+++ b/src/Garn/Common.hs
@@ -3,9 +3,9 @@ module Garn.Common (nixpkgsInput, nixArgs, currentSystem) where
 import Data.Aeson (eitherDecode)
 import Development.Shake (Stdout (..), cmd)
 
--- | pinned to release-23.05 on 2023-10-21
+-- | pinned to master on 2023-10-26
 nixpkgsInput :: String
-nixpkgsInput = "github:NixOS/nixpkgs/21443a102b1a2f037d02e1d22e3e0ffdda2dbff9"
+nixpkgsInput = "github:NixOS/nixpkgs/6fc7203e423bbf1c8f84cccf1c4818d097612566"
 
 nixArgs :: [String]
 nixArgs =

--- a/src/Garn/Optparse.hs
+++ b/src/Garn/Optparse.hs
@@ -93,8 +93,9 @@ enterCommand targets =
 checkCommand :: Targets -> Parser WithGarnTsCommand
 checkCommand targets =
   let checkCommandOptions =
-        Qualified <$> commandOptionsParser (Map.filter isProject targets)
-          <|> pure Unqualified
+        Qualified
+          <$> commandOptionsParser (Map.filter isProject targets)
+            <|> pure Unqualified
    in Check <$> checkCommandOptions
 
 isProject :: TargetConfig -> Bool

--- a/ts/edit.ts
+++ b/ts/edit.ts
@@ -52,7 +52,7 @@ const stateFile = (): Package => {
   `;
   const sqliteScriptFile: NixExpression = writeTextFile(
     "sqlite-script",
-    sqliteScript
+    sqliteScript,
   );
   return garn.build`
     set -euo pipefail

--- a/ts/environment.ts
+++ b/ts/environment.ts
@@ -125,7 +125,7 @@ export function build(
  */
 export function mkEnvironment(
   nixExpression = nixRaw`pkgs.mkShell {}`,
-  setup?: NixExpression
+  setup?: NixExpression,
 ): Environment {
   return {
     tag: "environment",
@@ -237,5 +237,5 @@ export const packageToEnvironment = (pkg: Package, src: string): Environment =>
       cp -r ${nixSource(src)} src
       chmod -R u+rwX src
       cd src
-    `
+    `,
   );

--- a/ts/executable.ts
+++ b/ts/executable.ts
@@ -38,7 +38,7 @@ export function isExecutable(e: unknown): e is Executable {
  */
 export function mkExecutable(
   nixExpression: NixExpression,
-  description: string
+  description: string,
 ): Executable {
   return {
     tag: "executable",

--- a/ts/go/initializers.ts
+++ b/ts/go/initializers.ts
@@ -31,7 +31,7 @@ const goModuleInitializer: Initializer = () => {
   }
   try {
     const { goVersion, moduleName } = parseGoMod(
-      Deno.readTextFileSync("go.mod")
+      Deno.readTextFileSync("go.mod"),
     );
     return {
       tag: "ShouldRun",

--- a/ts/go/mod.ts
+++ b/ts/go/mod.ts
@@ -29,13 +29,13 @@ const getGoModNixToml = (src: string): NixExpression => {
         "",
         "Stderr:",
         new TextDecoder().decode(gen.stderr),
-      ].join("\n")
+      ].join("\n"),
     );
   }
   return nixStrLit(
     Deno.readTextFileSync(
-      path.join(getDotGarnProjectDir(src), "gomod2nix.toml")
-    )
+      path.join(getDotGarnProjectDir(src), "gomod2nix.toml"),
+    ),
   );
 };
 
@@ -60,19 +60,19 @@ export function mkGoProject(args: {
       let
         gomod2nix = gomod2nix-repo.legacyPackages.\${system};
         gomod2nix-toml = pkgs.writeText "gomod2nix-toml" ${getGoModNixToml(
-          args.src
+          args.src,
         )};
       in
         gomod2nix.buildGoApplication {
           pname = "go-package";
           version = "0.1";
           go = pkgs.${nixRaw(
-            GO_VERSION_TO_NIXPKG_NAME[args.goVersion ?? "1.20"]
+            GO_VERSION_TO_NIXPKG_NAME[args.goVersion ?? "1.20"],
           )};
           src = ${nixSource(args.src)};
           modules = gomod2nix-toml;
         }
-    `
+    `,
   );
 
   return mkProject(
@@ -84,6 +84,6 @@ export function mkGoProject(args: {
     },
     {
       pkg,
-    }
+    },
   );
 }

--- a/ts/haskell/initializers.ts
+++ b/ts/haskell/initializers.ts
@@ -59,7 +59,7 @@ Deno.test("Initializer errors if the cabal file is unparseable", () => {
     "./foo.cabal",
     `
     name: foo
-  `
+  `,
   );
   const result = mkHaskellProjectInitializer();
   assertEquals(result.tag, "UnexpectedError");
@@ -76,7 +76,7 @@ Deno.test("Initializer returns a simple string if a cabal file exists", () => {
     `
     name: foo
     version: 0.0.1
-  `
+  `,
   );
   const result = mkHaskellProjectInitializer();
   assertEquals(result.tag, "ShouldRun");
@@ -89,7 +89,7 @@ Deno.test("Initializer returns a simple string if a cabal file exists", () => {
             executable: "",
             compiler: "ghc94",
             src: "."
-          })`
+          })`,
     );
   }
 });

--- a/ts/haskell/mod.ts
+++ b/ts/haskell/mod.ts
@@ -30,10 +30,10 @@ export function mkHaskellProject(args: {
     },
     {
       pkg,
-    }
+    },
   ).withDevTools([
     mkPackage(
-      nixRaw`pkgs.haskell.packages.${nixRaw(args.compiler)}.cabal-install`
+      nixRaw`pkgs.haskell.packages.${nixRaw(args.compiler)}.cabal-install`,
     ),
   ]);
 }

--- a/ts/internal/init.ts
+++ b/ts/internal/init.ts
@@ -77,5 +77,5 @@ Deno.writeTextFileSync(
 ${imports.join("\n")}
 
 ${initializedSections.join("\n")}
-`.trim() + "\n"
+`.trim() + "\n",
 );

--- a/ts/internal/may_not_export.ts
+++ b/ts/internal/may_not_export.ts
@@ -18,7 +18,7 @@ const MAY_NOT_EXPORT = Symbol();
 export function markAsMayNotExport(
   // deno-lint-ignore ban-types
   value: object,
-  reason: (exportName: string) => string
+  reason: (exportName: string) => string,
 ) {
   // @ts-expect-error - SAFETY: typescript does not allow setting
   // `MAY_NOT_EXPORT` on T here. However, it is safe to set arbitrary keys on

--- a/ts/internal/registerInternalLib.ts
+++ b/ts/internal/registerInternalLib.ts
@@ -3,7 +3,7 @@ import { DenoOutput, toDenoOutput } from "./runner.ts";
 type InternalLibrary = {
   toDenoOutput: (
     nixpkgsInput: string,
-    garnExports: Record<string, unknown>
+    garnExports: Record<string, unknown>,
   ) => DenoOutput;
 };
 
@@ -14,7 +14,7 @@ const garnGetInternalLib = (): InternalLibrary => ({
 // deno-lint-ignore no-explicit-any
 if ((window as any).__garnGetInternalLib != null) {
   throw new Error(
-    "Registering __garnGetInternalLib twice, using two different garn library versions is not supported."
+    "Registering __garnGetInternalLib twice, using two different garn library versions is not supported.",
   );
 }
 // deno-lint-ignore no-explicit-any

--- a/ts/internal/runner.ts
+++ b/ts/internal/runner.ts
@@ -37,7 +37,7 @@ type ExecutableTarget = {
 
 export const toDenoOutput = (
   nixpkgsInput: string,
-  garnExports: Record<string, unknown>
+  garnExports: Record<string, unknown>,
 ): DenoOutput => {
   try {
     return {
@@ -62,7 +62,7 @@ export const toDenoOutput = (
 const toTargets = (garnExports: Record<string, unknown>): Targets => {
   const result: Targets = {};
   for (const [name, exportable] of Object.entries(
-    findExportables(garnExports)
+    findExportables(garnExports),
   )) {
     if (isProject(exportable)) {
       const packages = collectProjectPackages(name, exportable);
@@ -87,13 +87,13 @@ const toTargets = (garnExports: Record<string, unknown>): Targets => {
 
 const formatFlake = (
   nixpkgsInput: string,
-  garnExports: Record<string, unknown>
+  garnExports: Record<string, unknown>,
 ): NixExpression => {
   const exportables = findExportables(garnExports);
 
   const packages = mapValues(
     (p) => p.nixExpression,
-    collectPackages(exportables)
+    collectPackages(exportables),
   );
   const checks = mapValues((p) => p.nixExpression, collectChecks(exportables));
   const shells = mapValues(
@@ -101,7 +101,7 @@ const formatFlake = (
       isProject(exportable) && exportable.defaultEnvironment
         ? exportable.defaultEnvironment.nixExpression
         : undefined,
-    exportables
+    exportables,
   );
   const apps = mapValues((exportable) => {
     if (isProject(exportable) && exportable.defaultExecutable) {
@@ -171,7 +171,7 @@ const formatFlake = (
 type Exportable = Project | Executable;
 
 const findExportables = (
-  config: Record<string, unknown>
+  config: Record<string, unknown>,
 ): Record<string, Exportable> => {
   const result: Record<string, Exportable> = {};
   for (const [name, value] of Object.entries(config)) {
@@ -191,7 +191,7 @@ const findExportables = (
 };
 
 const collectPackages = (
-  config: Record<string, Exportable>
+  config: Record<string, Exportable>,
 ): Record<string, Package> => {
   let result: Record<string, Package> = {};
   for (const [name, exportable] of Object.entries(config)) {
@@ -207,15 +207,15 @@ const collectPackages = (
 
 const collectProjectPackages = (
   projectName: string,
-  project: Project
+  project: Project,
 ): Record<string, Package> =>
   mapKeys(
     (name) => `${projectName}_${name}`,
-    collectByPredicate(isPackage, project)
+    collectByPredicate(isPackage, project),
   );
 
 const collectChecks = (
-  config: Record<string, Exportable>
+  config: Record<string, Exportable>,
 ): Record<string, Check> => {
   let result: Record<string, Check> = {};
   for (const [name, exportable] of Object.entries(config)) {
@@ -231,16 +231,16 @@ const collectChecks = (
 
 const collectProjectChecks = (
   projectName: string,
-  project: Project
+  project: Project,
 ): Record<string, Check> =>
   mapKeys(
     (name) => `${projectName}_${name}`,
-    collectByPredicate(isCheck, project)
+    collectByPredicate(isCheck, project),
   );
 
 const collectByPredicate = <T>(
   predicate: (t: unknown) => t is T,
-  project: Project
+  project: Project,
 ): Record<string, T> => {
   const result: Record<string, T> = {};
   for (const [name, value] of Object.entries(project)) {

--- a/ts/internal/utils.ts
+++ b/ts/internal/utils.ts
@@ -31,7 +31,7 @@ export const hasTag = (x: unknown, tag: unknown): boolean =>
 
 export const mapKeys = <T>(
   f: (i: string) => string,
-  x: Record<string, T>
+  x: Record<string, T>,
 ): Record<string, T> => {
   const result: Record<string, T> = {};
   for (const [key, value] of Object.entries(x)) {
@@ -47,7 +47,7 @@ export const mapKeys = <T>(
  */
 export const mapValues = <T, R>(
   f: (i: T) => R,
-  x: Record<string, T>
+  x: Record<string, T>,
 ): Record<string, R> => {
   const result: Record<string, R> = {};
   for (const [key, value] of Object.entries(x)) {
@@ -62,7 +62,7 @@ export const checkExhaustiveness = (x: never): never => {
 
 export const writeTextFile = (
   name: string,
-  text: string
+  text: string,
 ): NixExpression => nixRaw`
   pkgs.writeTextFile {
     name = ${nixStrLit`${name}`};

--- a/ts/javascript/mod.ts
+++ b/ts/javascript/mod.ts
@@ -26,7 +26,7 @@ const nodeVersions = {
 type NodeVersion = keyof typeof nodeVersions;
 
 const fromNodeVersion = (
-  version: NodeVersion
+  version: NodeVersion,
 ): { pkgs: NixExpression; nodejs: NixExpression } => {
   const { pkg, permittedInsecurePackages } = nodeVersions[version];
   return {
@@ -75,7 +75,7 @@ export function mkNpmProject(args: {
       echo copying node_modules
       cp -r ${node_modules}/node_modules .
       chmod -R u+rwX node_modules
-    `
+    `,
   ).withDevTools([mkPackage(nodejs)]);
   return mkProject(
     {
@@ -85,7 +85,7 @@ export function mkNpmProject(args: {
     {
       devShell,
       node_modules,
-    }
+    },
   );
 }
 
@@ -116,7 +116,7 @@ export function mkYarnProject(args: {
         packageJson = pkgs.lib.importJSON ${nixRaw(args.src)}/package.json;
         yarnPackage = ${yarnPackage};
         nodeModulesPath = ${nixStrLit`${nixRaw("yarnPackage")}/libexec/${nixRaw(
-          "packageJson.name"
+          "packageJson.name",
         )}/node_modules`};
     in
       (pkgs.writeScriptBin "start-server" ${nixStrLit`
@@ -137,7 +137,7 @@ export function mkYarnProject(args: {
           packageJson = pkgs.lib.importJSON ${nixRaw(args.src)}/package.json;
           yarnPackage = ${yarnPackage};
           nodeModulesPath = ${nixStrLit`${nixRaw(
-            "yarnPackage"
+            "yarnPackage",
           )}/libexec/${nixRaw("packageJson.name")}/node_modules`};
       in
         pkgs.mkShell {
@@ -153,7 +153,7 @@ export function mkYarnProject(args: {
       cp -r ${nixSource(args.src)} src
       chmod -R u+rwX src
       cd src
-    `
+    `,
   );
   const startDev: Executable = devShell.shell`cd ${args.src} && ${startCommand}`;
   return mkProject(
@@ -166,6 +166,6 @@ export function mkYarnProject(args: {
       pkg,
       devShell,
       startDev,
-    }
+    },
   );
 }

--- a/ts/nix.ts
+++ b/ts/nix.ts
@@ -70,7 +70,7 @@ export function nixRaw(
   const rawNixExpressionString = s.reduce(
     (acc, part, i) =>
       acc + part + (interpolations[i]?.rawNixExpressionString ?? ""),
-    ""
+    "",
   );
   return { rawNixExpressionString };
 }
@@ -90,7 +90,7 @@ export function nixRaw(
  */
 export function nixList(elements: Array<NixExpression>): NixExpression {
   return nixRaw(
-    "[" + elements.map((p) => p.rawNixExpressionString.trim()).join(" ") + "]"
+    "[" + elements.map((p) => p.rawNixExpressionString.trim()).join(" ") + "]",
   );
 }
 
@@ -107,7 +107,7 @@ export function nixList(elements: Array<NixExpression>): NixExpression {
  * ```
  */
 export function nixAttrSet(
-  attrSet: Record<string, NixExpression | undefined>
+  attrSet: Record<string, NixExpression | undefined>,
 ): NixExpression {
   return nixRaw(
     "{" +
@@ -115,7 +115,7 @@ export function nixAttrSet(
         .filter((x): x is [string, NixExpression] => x[1] != null)
         .map(([k, v]) => nixRaw`${nixStrLit(k)} = ${v};`.rawNixExpressionString)
         .join("\n") +
-      "}"
+      "}",
   );
 }
 
@@ -138,7 +138,7 @@ export function nixStrLit(
   const escape = (str: string) =>
     ["\\", '"', "$"].reduce(
       (str, char) => str.replaceAll(char, `\\${char}`),
-      str
+      str,
     );
   const escapedTemplate = s.map(escape);
   const rawNixExpressionString =
@@ -173,21 +173,21 @@ Deno.test("nixStrLit correctly serializes into a nix expression", () => {
   assertEquals(nixStrLit`foo`.rawNixExpressionString, '"foo"');
   assertEquals(
     nixStrLit`with ${"string"} interpolation`.rawNixExpressionString,
-    '"with string interpolation"'
+    '"with string interpolation"',
   );
   assertEquals(
     nixStrLit`with package ${{
       rawNixExpressionString: "pkgs.hello",
     }} works`.rawNixExpressionString,
-    '"with package ${pkgs.hello} works"'
+    '"with package ${pkgs.hello} works"',
   );
   assertEquals(
     nixStrLit`escaped dollars in strings \${should not interpolate}`
       .rawNixExpressionString,
-    '"escaped dollars in strings \\${should not interpolate}"'
+    '"escaped dollars in strings \\${should not interpolate}"',
   );
   assertEquals(
     nixStrLit`"double quotes" are correctly escaped`.rawNixExpressionString,
-    '"\\"double quotes\\" are correctly escaped"'
+    '"\\"double quotes\\" are correctly escaped"',
   );
 });

--- a/ts/package.ts
+++ b/ts/package.ts
@@ -27,7 +27,7 @@ export function isPackage(x: unknown): x is Package {
  */
 export function mkPackage(
   nixExpression: NixExpression,
-  description?: string
+  description?: string,
 ): Package {
   return {
     tag: "package",

--- a/ts/process_compose.ts
+++ b/ts/process_compose.ts
@@ -12,7 +12,7 @@ import { mkPackage } from "./package.ts";
  * development, e.g. a backend server and a database.
  */
 export function processCompose(
-  executables: Record<string, Executable>
+  executables: Record<string, Executable>,
 ): Executable {
   const processes = nixAttrSet(
     mapValues(
@@ -21,8 +21,8 @@ export function processCompose(
           command: executable.nixExpression,
           environment: nixList([]),
         }),
-      executables
-    )
+      executables,
+    ),
   );
 
   const processComposeConfig = nixAttrSet({
@@ -31,7 +31,7 @@ export function processCompose(
   });
 
   const configYml = mkPackage(
-    nixRaw`pkgs.writeText "process-compose.yml" (builtins.toJSON ${processComposeConfig})`
+    nixRaw`pkgs.writeText "process-compose.yml" (builtins.toJSON ${processComposeConfig})`,
   );
 
   const result = emptyEnvironment.shell`${nixRaw`pkgs.process-compose`}/bin/process-compose up -f ${configYml}`;

--- a/ts/project.ts
+++ b/ts/project.ts
@@ -68,7 +68,7 @@ type ProjectHelpers = {
    */
   addExecutable<T extends Project, Name extends string>(
     this: T,
-    name: Name
+    name: Name,
   ): (
     _s: TemplateStringsArray,
     ..._args: Array<string>
@@ -85,7 +85,7 @@ type ProjectHelpers = {
    */
   addCheck<T extends Project, Name extends string>(
     this: T,
-    name: Name
+    name: Name,
   ): (
     _s: TemplateStringsArray,
     ..._args: Array<string>
@@ -110,7 +110,7 @@ export function mkProject<Deps extends Record<string, Nestable>>(
     defaultEnvironment?: Environment;
     defaultExecutable?: Executable;
   },
-  deps: Deps
+  deps: Deps,
 ): Deps & Project {
   const helpers = proxyEnvironmentHelpers();
   return {
@@ -131,7 +131,7 @@ const proxyEnvironmentHelpers = (): ProjectHelpers => ({
   ) {
     if (this.defaultEnvironment == null) {
       throw new Error(
-        `'.shell' can only be called on projects with a default environment`
+        `'.shell' can only be called on projects with a default environment`,
       );
     }
     return this.defaultEnvironment.shell(s, ...args);
@@ -144,7 +144,7 @@ const proxyEnvironmentHelpers = (): ProjectHelpers => ({
   ) {
     if (this.defaultEnvironment == null) {
       throw new Error(
-        `'.check' can only be called on projects with a default environment`
+        `'.check' can only be called on projects with a default environment`,
       );
     }
     return this.defaultEnvironment.check(s, ...args);
@@ -157,7 +157,7 @@ const proxyEnvironmentHelpers = (): ProjectHelpers => ({
   ) {
     if (this.defaultEnvironment == null) {
       throw new Error(
-        `'.build' can only be called on projects with a default environment`
+        `'.build' can only be called on projects with a default environment`,
       );
     }
     return this.defaultEnvironment.build(s, ...args);
@@ -166,7 +166,7 @@ const proxyEnvironmentHelpers = (): ProjectHelpers => ({
   addExecutable<T extends Project, Name extends string>(this: T, name: Name) {
     if (this.defaultEnvironment == null) {
       throw new Error(
-        `'.addExecutable' can only be called on projects with a default environment`
+        `'.addExecutable' can only be called on projects with a default environment`,
       );
     }
     const templateLiteralFn = (
@@ -185,7 +185,7 @@ const proxyEnvironmentHelpers = (): ProjectHelpers => ({
       [
         `${exportName} exports the return type of "addExecutable", but this is not the proper usage of addExecutable.`,
         'Did you forget the template literal? Example usage: project.addExecutable("executable-name")`shell script to run`',
-      ].join(" ")
+      ].join(" "),
     );
     return templateLiteralFn;
   },
@@ -193,7 +193,7 @@ const proxyEnvironmentHelpers = (): ProjectHelpers => ({
   addCheck<T extends Project, Name extends string>(this: T, name: Name) {
     if (this.defaultEnvironment == null) {
       throw new Error(
-        `'.addCheck' can only be called on projects with a default environment`
+        `'.addCheck' can only be called on projects with a default environment`,
       );
     }
     const templateLiteralFn = (
@@ -212,7 +212,7 @@ const proxyEnvironmentHelpers = (): ProjectHelpers => ({
       [
         `${exportName} exports the return type of "addCheck", but this is not the proper usage of addCheck.`,
         'Did you forget the template literal? Example usage: project.addCheck("check-name")`shell script to run`',
-      ].join(" ")
+      ].join(" "),
     );
     return templateLiteralFn;
   },
@@ -220,7 +220,7 @@ const proxyEnvironmentHelpers = (): ProjectHelpers => ({
   withDevTools<T extends Project>(this: T, devTools: Array<Package>): T {
     if (this.defaultEnvironment == null) {
       throw new Error(
-        `'.withDevTools' can only be called on projects with a default environment`
+        `'.withDevTools' can only be called on projects with a default environment`,
       );
     }
     const newEnvironment = this.defaultEnvironment.withDevTools(devTools);

--- a/website/flake.lock
+++ b/website/flake.lock
@@ -74,17 +74,17 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1697912416,
-        "narHash": "sha256-2MLnJ9vLbiSyfA+mYHPdN76qAOfacJw/dX/sSiYdo2o=",
+        "lastModified": 1698376214,
+        "narHash": "sha256-8UC0cK/cT600ug+8RVc6a1sE66+U1dfsileTo65zPCg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "21443a102b1a2f037d02e1d22e3e0ffdda2dbff9",
+        "rev": "6fc7203e423bbf1c8f84cccf1c4818d097612566",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "21443a102b1a2f037d02e1d22e3e0ffdda2dbff9",
+        "rev": "6fc7203e423bbf1c8f84cccf1c4818d097612566",
         "type": "github"
       }
     },

--- a/website/flake.nix
+++ b/website/flake.nix
@@ -1,5 +1,5 @@
 {
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/21443a102b1a2f037d02e1d22e3e0ffdda2dbff9";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/6fc7203e423bbf1c8f84cccf1c4818d097612566";
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.gomod2nix-repo.url = "github:nix-community/gomod2nix?rev=f95720e89af6165c8c0aa77f180461fe786f3c21";
   inputs.npmlock2nix-repo = {


### PR DESCRIPTION
Currently we recommend in the getting started guide to put `deno` into a garner
environment to make it available for editing `garn.ts` files. However it's not
the same `deno` version, `garn` currently uses `1.34.1`, but in the generated
`nixpkgs.ts` it's `1.33.3`. After this PR it'll be `1.37.2` in both places.

I've updated the patch-level version of `ghc` since 9.4.7 is the default for
that branch and it seemed that more libraries where cached on cache.nixos.org
for that.
