### PR TITLE
Implement deno <-> haskell JSON version check

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ dependencies.
 For example, with this `garn.ts` file:
 
 ```typescript
-import * as garn from "https://garn.io/ts/v0.0.12/mod.ts";
+import * as garn from "https://garn.io/ts/v0.0.13/mod.ts";
 
 export const frontend = garn.javascript.mkNpmProject({
   description: "My project frontend",
@@ -89,4 +89,4 @@ reproducible.
 ## Typescript API
 
 Documentation for the `garn` Deno library is documented
-[here](https://doc.deno.land/https://garn.io/ts/v0.0.12/mod.ts).
+[here](https://doc.deno.land/https://garn.io/ts/v0.0.13/mod.ts).

--- a/examples/getting-started/garn.ts
+++ b/examples/getting-started/garn.ts
@@ -1,5 +1,5 @@
-import * as garn from "https://garn.io/ts/v0.0.12/mod.ts";
-import * as pkgs from "https://garn.io/ts/v0.0.12/nixpkgs.ts";
+import * as garn from "https://garn.io/ts/v0.0.13/mod.ts";
+import * as pkgs from "https://garn.io/ts/v0.0.13/nixpkgs.ts";
 
 export const frontend = garn.javascript
   .mkNpmProject({

--- a/src/Garn/Errors.hs
+++ b/src/Garn/Errors.hs
@@ -3,6 +3,6 @@ module Garn.Errors where
 import Control.Exception (Exception)
 
 data UserError = UserError String
-  deriving stock (Show)
+  deriving stock (Eq, Show)
 
 instance Exception UserError

--- a/test/spec/InitSpec.hs
+++ b/test/spec/InitSpec.hs
@@ -31,8 +31,8 @@ spec = do
           readFile "garn.ts"
             `shouldReturn` unindent
               [i|
-                import * as garn from "https://garn.io/ts/v0.0.12/mod.ts";
-                import * as pkgs from "https://garn.io/ts/v0.0.12/nixpkgs.ts";
+                import * as garn from "https://garn.io/ts/v0.0.13/mod.ts";
+                import * as pkgs from "https://garn.io/ts/v0.0.13/nixpkgs.ts";
 
                 export const garn = garn.haskell.mkHaskellProject({
                   description: "",
@@ -55,8 +55,8 @@ spec = do
           readFile "garn.ts"
             `shouldReturn` unindent
               [i|
-                import * as garn from "https://garn.io/ts/v0.0.12/mod.ts";
-                import * as pkgs from "https://garn.io/ts/v0.0.12/nixpkgs.ts";
+                import * as garn from "https://garn.io/ts/v0.0.13/mod.ts";
+                import * as pkgs from "https://garn.io/ts/v0.0.13/nixpkgs.ts";
 
                 export const someGoProject = garn.go.mkGoProject({
                   description: "My go project",

--- a/ts/environment.ts
+++ b/ts/environment.ts
@@ -85,7 +85,7 @@ export function check(
  *
  * Example:
  * ```typescript
- * import * as pkgs from "https://garn.io/ts/v0.0.12/nixpkgs.ts";
+ * import * as pkgs from "https://garn.io/ts/v0.0.13/nixpkgs.ts";
  *
  * garn.build`
  *   ${pkgs.cowsay}/bin/cowsay moo > $out/moo
@@ -210,7 +210,7 @@ export function mkEnvironment(
  *
  * For example:
  * ```typescript
- * import * as pkgs from "https://garn.io/ts/v0.0.12/nixpkgs.ts";
+ * import * as pkgs from "https://garn.io/ts/v0.0.13/nixpkgs.ts";
  *
  * // Create an environment with nothing but go and gopls installed:
  * emptyEnvironment.withDevTools([pkgs.go, pkgs.gopls])

--- a/ts/internal/init.ts
+++ b/ts/internal/init.ts
@@ -1,12 +1,11 @@
 import * as haskell from "../haskell/initializers.ts";
 import * as go from "../go/initializers.ts";
 import outdent from "https://deno.land/x/outdent@v0.8.0/mod.ts";
-
-const GARN_VERSION = "v0.0.12";
+import { GARN_TS_LIB_VERSION } from "./utils.ts";
 
 const imports = [
-  `import * as garn from "https://garn.io/ts/${GARN_VERSION}/mod.ts";`,
-  `import * as pkgs from "https://garn.io/ts/${GARN_VERSION}/nixpkgs.ts";`,
+  `import * as garn from "https://garn.io/ts/${GARN_TS_LIB_VERSION}/mod.ts";`,
+  `import * as pkgs from "https://garn.io/ts/${GARN_TS_LIB_VERSION}/nixpkgs.ts";`,
 ];
 const initializedSections = [];
 

--- a/ts/internal/runner.ts
+++ b/ts/internal/runner.ts
@@ -1,7 +1,12 @@
 import { isProject, Project } from "../project.ts";
 import { isPackage, Package } from "../package.ts";
 import { Check, isCheck } from "../check.ts";
-import { checkExhaustiveness, mapKeys, mapValues } from "./utils.ts";
+import {
+  checkExhaustiveness,
+  GARN_TS_LIB_VERSION,
+  mapKeys,
+  mapValues,
+} from "./utils.ts";
 import { GOMOD2NIX_REPO } from "../go/consts.ts";
 import { nixAttrSet, NixExpression, nixRaw, nixStrLit } from "../nix.ts";
 import { Executable } from "../mod.ts";
@@ -11,8 +16,8 @@ import { UserError } from "./errors.ts";
 
 // This needs to be in sync with `DenoOutput` in GarnConfig.hs
 export type DenoOutput =
-  | { tag: "Success"; contents: GarnConfig }
-  | { tag: "UserError"; contents: string };
+  | { garnTsLibVersion: string; tag: "Success"; contents: GarnConfig }
+  | { garnTsLibVersion: string; tag: "UserError"; contents: string };
 
 export type GarnConfig = {
   targets: Targets;
@@ -41,6 +46,7 @@ export const toDenoOutput = (
 ): DenoOutput => {
   try {
     return {
+      garnTsLibVersion: GARN_TS_LIB_VERSION,
       tag: "Success",
       contents: {
         targets: toTargets(garnExports),
@@ -51,6 +57,7 @@ export const toDenoOutput = (
   } catch (err: unknown) {
     if (err instanceof UserError) {
       return {
+        garnTsLibVersion: GARN_TS_LIB_VERSION,
         tag: "UserError",
         contents: err.message,
       };

--- a/ts/internal/utils.ts
+++ b/ts/internal/utils.ts
@@ -1,6 +1,6 @@
 import { NixExpression, nixRaw, nixStrLit } from "../nix.ts";
 
-export const GARN_TS_LIB_VERSION = "v0.0.12";
+export const GARN_TS_LIB_VERSION = "v0.0.13";
 
 export const nixSource = (src: string): NixExpression => nixRaw`
   (let

--- a/ts/internal/utils.ts
+++ b/ts/internal/utils.ts
@@ -1,5 +1,7 @@
 import { NixExpression, nixRaw, nixStrLit } from "../nix.ts";
 
+export const GARN_TS_LIB_VERSION = "v0.0.12";
+
 export const nixSource = (src: string): NixExpression => nixRaw`
   (let
     lib = pkgs.lib;

--- a/website/src/docs/concepts.mdx
+++ b/website/src/docs/concepts.mdx
@@ -18,11 +18,11 @@ of the above entities and give them structure. `Project`s are described at the
 bottom in the [Projects](#projects) section.
 
 All of these concepts are implemented as typescript types. Feel free to browse
-the [API docs](https://doc.deno.land/https://garn.io/ts/v0.0.12/mod.ts) as well.
+the [API docs](https://doc.deno.land/https://garn.io/ts/v0.0.13/mod.ts) as well.
 
 ## Environments
 
-(See also the [API docs](https://doc.deno.land/https://garn.io/ts/v0.0.12/mod.ts/~/Environment).)
+(See also the [API docs](https://doc.deno.land/https://garn.io/ts/v0.0.13/mod.ts/~/Environment).)
 
 `Environment`s define what is available to a computation. For example they can
 contain compilers and developer tools that you want to use on a project, but
@@ -42,7 +42,7 @@ what the `Environment`s provide. For example `Check`s, which are our next topic.
 
 ## Checks
 
-(See also the [API docs](https://doc.deno.land/https://garn.io/ts/v0.0.12/mod.ts/~/Check).)
+(See also the [API docs](https://doc.deno.land/https://garn.io/ts/v0.0.13/mod.ts/~/Check).)
 
 `Check`s are commands (usually shell commands) that are used to define
 reproducible, automated tests or other checks. They run in a sandbox, which
@@ -65,7 +65,7 @@ configuration.
 
 ## Executables
 
-(See also the [API docs](https://doc.deno.land/https://garn.io/ts/v0.0.12/mod.ts/~/Executable).)
+(See also the [API docs](https://doc.deno.land/https://garn.io/ts/v0.0.13/mod.ts/~/Executable).)
 
 `Executable`s are commands (usually shell snippets) that are being run on your
 local machine (not in a sandbox). They are based on an underlying `Environment`,
@@ -81,7 +81,7 @@ and can make use of e.g. the tools that `Environment`s provide. You can use
 Here's a small example:
 
 ```typescript
-import * as garn from "https://garn.io/ts/v0.0.12/mod.ts";
+import * as garn from "https://garn.io/ts/v0.0.13/mod.ts";
 
 export const hello =
   garn.emptyEnvironment.shell`echo Hello, world!`;
@@ -91,7 +91,7 @@ You can run `Executable`s with `garn run`.
 
 ## Packages
 
-(See also the [API docs](https://doc.deno.land/https://garn.io/ts/v0.0.12/mod.ts/~/Package).)
+(See also the [API docs](https://doc.deno.land/https://garn.io/ts/v0.0.13/mod.ts/~/Package).)
 
 `Package`s are instructions to `garn` about how to _build_ a set of files. For
 example for a go backend a package would define how to compile it into
@@ -107,7 +107,7 @@ You can build `Package`s with `garn build`.
 
 ## Projects
 
-(See also the [API docs](https://doc.deno.land/https://garn.io/ts/v0.0.12/mod.ts/~/Project).)
+(See also the [API docs](https://doc.deno.land/https://garn.io/ts/v0.0.13/mod.ts/~/Project).)
 
 `Project`s are used to combine `Environment`s, `Check`s, `Executable`s and
 `Package`s into a single entity. A `Project` can contain any number of these
@@ -126,8 +126,8 @@ that contains a few `Check`s and adds a developer tool to its default
 environment:
 
 ```typescript
-import * as garn from "https://garn.io/ts/v0.0.12/mod.ts";
-import * as pkgs from "https://garn.io/ts/v0.0.12/nixpkgs.ts";
+import * as garn from "https://garn.io/ts/v0.0.13/mod.ts";
+import * as pkgs from "https://garn.io/ts/v0.0.13/nixpkgs.ts";
 
 export const project = garn.javascript
   .mkNpmProject({

--- a/website/src/docs/getting_started.mdx
+++ b/website/src/docs/getting_started.mdx
@@ -109,4 +109,4 @@ for more info.
 ## Further reading
 
 - [garn concepts](/docs/concepts)
-- [typescript api](https://doc.deno.land/https://garn.io/ts/v0.0.12/mod.ts)
+- [typescript api](https://doc.deno.land/https://garn.io/ts/v0.0.13/mod.ts)

--- a/website/src/pages/docs.tsx
+++ b/website/src/pages/docs.tsx
@@ -20,7 +20,7 @@ export const docMenuItems: { name: string; url: string }[] = [
   ...docEntries.map(([{ name, url }]) => ({ name, url: `/docs/${url}` })),
   {
     name: "typescript api",
-    url: "https://doc.deno.land/https://garn.io/ts/v0.0.12/mod.ts",
+    url: "https://doc.deno.land/https://garn.io/ts/v0.0.13/mod.ts",
   },
 ];
 

--- a/website/src/pages/main.tsx
+++ b/website/src/pages/main.tsx
@@ -24,7 +24,7 @@ const Export: React.FC = (props) => (
 const garnTs = (
   <pre>
     <Keyword>import</Keyword> * as garn from{" "}
-    <String>"https://garn.io/ts/v0.0.12/mod.ts"</String>;<br />
+    <String>"https://garn.io/ts/v0.0.13/mod.ts"</String>;<br />
     <Keyword>import</Keyword> * as{" "}
     <Tooltip item="pkgs">
       {`This is a gigantic collection
@@ -32,7 +32,7 @@ of packages, nixpkgs. If you
 need a tool or dependency,
 it's probably here`}
     </Tooltip>{" "}
-    from <String>"https://garn.io/ts/v0.0.12/nixpkgs.ts"</String>;<br />
+    from <String>"https://garn.io/ts/v0.0.13/nixpkgs.ts"</String>;<br />
     <br />
     <Export>export</Export> <Keyword>const</Keyword> frontend =
     garn.javascript.mkNpmProject(&#123; <br />


### PR DESCRIPTION
This implements a first step in the direction of #317 and should make error messages on json version mismatches much better. Once we have #306, the error message should include a link to that.

Since this is a breaking change to the json format this PR also bumps the ts lib version. But from this version onwards we should have better error messages. :)