### PR TITLE
Simpler versions of `addCheck` and `addExecutable`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ export const frontend = garn.javascript.mkNpmProject({
   src: "frontend",
   nodeVersion: "18",
 })
-  .addExecutable("run")`cd frontend && npm install && npm start`;
+  .addExecutable("run", "cd frontend && npm install && npm start");
 
 export const backend = garn.go.mkGoProject({
   description: "My project backend",
   src: "backend",
   goVersion: "1.20",
 })
-  .addExecutable("run")`cd backend && go run ./main.go`;
+  .addExecutable("run", "cd backend && go run ./main.go");
 
 export const startAll = garn.processCompose({
   frontend: frontend.run,

--- a/examples/frontend-create-react-app/garn.ts
+++ b/examples/frontend-create-react-app/garn.ts
@@ -6,7 +6,7 @@ export const main = garn.javascript.mkNpmProject({
   nodeVersion: "18",
 });
 
-export const start = main.shell`npm install && npm start`;
+export const start = main.shell("npm install && npm start");
 
 export const bundle: garn.Project = garn.mkProject(
   {
@@ -17,5 +17,5 @@ export const bundle: garn.Project = garn.mkProject(
       npm run build
       cp -rv build/* $out
     `,
-  }
+  },
 );

--- a/examples/getting-started/garn.ts
+++ b/examples/getting-started/garn.ts
@@ -7,7 +7,7 @@ export const frontend = garn.javascript
     nodeVersion: "18",
     src: "./frontend",
   })
-  .addCheck("test")`npm test`;
+  .addCheck("test", "npm test");
 
 export const backend = garn.go.mkGoProject({
   description: "my backend",
@@ -20,7 +20,7 @@ export const deno = garn.mkProject(
     description: "garn configuration environment",
     defaultEnvironment: garn.emptyEnvironment.withDevTools([pkgs.deno]),
   },
-  {}
+  {},
 );
 
 export const edit = garn.editGarnConfig;

--- a/examples/go-http-backend/garn.ts
+++ b/examples/go-http-backend/garn.ts
@@ -1,9 +1,10 @@
 import * as garn from "http://localhost:8777/mod.ts";
 
-export const server: garn.Project = garn.go.mkGoProject({
-  description: "example backend server in go",
-  src: ".",
-  goVersion: "1.20",
-}).addExecutable("migrate")`go run ./scripts/migrate.go`
-  .addExecutable("dev")`go run ./main.go`;
-
+export const server: garn.Project = garn.go
+  .mkGoProject({
+    description: "example backend server in go",
+    src: ".",
+    goVersion: "1.20",
+  })
+  .addExecutable("migrate", "go run ./scripts/migrate.go")
+  .addExecutable("dev", "go run ./main.go");

--- a/examples/haskell/garn.ts
+++ b/examples/haskell/garn.ts
@@ -9,4 +9,4 @@ export const helloFromHaskell = garn.haskell
     src: ".",
   })
   .withDevTools([nixpkgs.hlint])
-  .addCheck("hlint")`hlint *.hs`;
+  .addCheck("hlint", "hlint *.hs");

--- a/examples/monorepo/garn.ts
+++ b/examples/monorepo/garn.ts
@@ -1,10 +1,11 @@
 import * as garn from "http://localhost:8777/mod.ts";
 
-export const backend = garn.go.mkGoProject({
-  description: "example backend server in go",
-  src: "backend",
-})
-  .addExecutable("run")`cd backend && go run ./main.go`;
+export const backend = garn.go
+  .mkGoProject({
+    description: "example backend server in go",
+    src: "backend",
+  })
+  .addExecutable("run", "cd backend && go run ./main.go");
 
 export const haskell = garn.haskell.mkHaskellProject({
   description: "My haskell executable",
@@ -13,12 +14,13 @@ export const haskell = garn.haskell.mkHaskellProject({
   src: "haskell",
 });
 
-export const npmFrontend = garn.javascript.mkNpmProject({
-  description: "frontend test app created by create-react-app",
-  src: "frontend-npm",
-  nodeVersion: "18",
-})
-  .addExecutable("run")`cd frontend-npm && npm install && npm start`;
+export const npmFrontend = garn.javascript
+  .mkNpmProject({
+    description: "frontend test app created by create-react-app",
+    src: "frontend-npm",
+    nodeVersion: "18",
+  })
+  .addExecutable("run", "cd frontend-npm && npm install && npm start");
 
 export const startAll = garn.processCompose({
   backend: backend.run,

--- a/examples/npm-project/garn.ts
+++ b/examples/npm-project/garn.ts
@@ -6,6 +6,7 @@ export const project = garn.javascript
     description: "An NPM frontend",
     nodeVersion: "18",
   })
-  .addCheck("test")`npm run test`.addCheck("tsc")`npm run tsc`;
+  .addCheck("test", "npm run test")
+  .addCheck("tsc", "npm run tsc");
 
-export const run = project.shell`npm install ; npm run run`;
+export const run = project.shell("npm install ; npm run run");

--- a/test/spec/CheckSpec.hs
+++ b/test/spec/CheckSpec.hs
@@ -44,7 +44,7 @@ spec = do
                 src: "."
               })
                 .withDevTools([garn.mkPackage(nixRaw`pkgs.hlint`)])
-                .addCheck("hlint")`hlint *.hs`;
+                .addCheck("hlint", "hlint *.hs");
             |]
           output <- runGarn ["check", "haskell"] "" repoDir Nothing
           onTestFailureLog output
@@ -81,9 +81,9 @@ spec = do
               export const failing = garn.mkProject(
                 { description: 'Failing Project' },
                 {
-                  check1: garn.check`echo ABC`,
-                  check2: garn.check`echo DEF && false`,
-                  check3: garn.check`echo GHI`,
+                  check1: garn.check("echo ABC"),
+                  check2: garn.check("echo DEF && false"),
+                  check3: garn.check("echo GHI"),
                 }
               );
             |]
@@ -107,6 +107,27 @@ spec = do
           output <- runGarn ["check", "myProject"] "" repoDir Nothing
           onTestFailureLog output
           stderr output `shouldContain` "hello world"
+          exitCode output `shouldBe` ExitFailure 1
+
+        it "allows to use backtick syntax" $ \onTestFailureLog -> do
+          writeHaskellProject repoDir
+          writeFile
+            "garn.ts"
+            [i|
+              import * as garn from "#{repoDir}/ts/mod.ts"
+              import { nixRaw } from "#{repoDir}/ts/nix.ts";
+
+              export const haskell = garn.mkProject(
+                {
+                  description: "",
+                  defaultEnvironment: garn.emptyEnvironment,
+                },
+                {},
+              ).addCheck("test-check")`echo error; false`;
+            |]
+          output <- runGarn ["check", "haskell"] "" repoDir Nothing
+          onTestFailureLog output
+          stderr output `shouldContain` "error"
           exitCode output `shouldBe` ExitFailure 1
 
         describe "exit-codes" $ do

--- a/test/spec/CheckSpec.hs
+++ b/test/spec/CheckSpec.hs
@@ -117,13 +117,15 @@ spec = do
               import * as garn from "#{repoDir}/ts/mod.ts"
               import { nixRaw } from "#{repoDir}/ts/nix.ts";
 
+              const hello: garn.Package = garn.mkPackage(nixRaw`pkgs.hello`);
+
               export const haskell = garn.mkProject(
                 {
                   description: "",
                   defaultEnvironment: garn.emptyEnvironment,
                 },
                 {},
-              ).addCheck("test-check")`echo error; false`;
+              ).addCheck("test-check")`${hello}/bin/hello; false`;
             |]
           output <- runGarn ["check", "haskell"] "" repoDir Nothing
           onTestFailureLog output

--- a/test/spec/RunSpec.hs
+++ b/test/spec/RunSpec.hs
@@ -150,17 +150,19 @@ spec =
             [i|
               import * as garn from "#{repoDir}/ts/mod.ts"
 
+              const hello = garn.mkPackage(garn.nix.nixRaw`pkgs.hello`);
+
               export const main = garn.mkProject(
                 {
                   description: "",
                   defaultEnvironment: garn.emptyEnvironment,
                 },
                 {},
-              ).addExecutable("foo")`echo foo`;
+              ).addExecutable("foo")`${hello}/bin/hello`;
             |]
           output <- runGarn ["run", "main.foo"] "" repoDir Nothing
           onTestFailureLog output
-          stdout output `shouldBe` "foo\n"
+          stdout output `shouldBe` "Hello, world!\n"
 
         describe "top-level executables" $ do
           it "shows top-level executables in the help" $ \onTestFailureLog -> do

--- a/ts/environment.ts
+++ b/ts/environment.ts
@@ -30,6 +30,7 @@ export type Environment = {
   /**
    * Creates a new shell script `Executable`, run inside this `Environment`
    */
+  shell(script: string): Executable;
   shell(
     _s: TemplateStringsArray,
     ..._args: Array<NixStrLitInterpolatable>
@@ -54,11 +55,18 @@ export type Environment = {
 /**
  * Creates a new shell script `Executable`, run in the `emptyEnvironment`.
  */
+export function shell(script: string): Executable;
 export function shell(
   s: TemplateStringsArray,
   ...args: Array<NixStrLitInterpolatable>
+): Executable;
+export function shell(
+  s: TemplateStringsArray | string,
+  ...args: Array<NixStrLitInterpolatable>
 ) {
-  return emptyEnvironment.shell(s, ...args);
+  return typeof s === "string"
+    ? emptyEnvironment.shell(s)
+    : emptyEnvironment.shell(s, ...args);
 }
 
 /**
@@ -162,8 +170,13 @@ export function mkEnvironment(
       `,
       };
     },
-    shell(this, s, ...args) {
-      const cmdToExecute = nixStrLit(s, ...args);
+    shell(
+      this: Environment,
+      s: TemplateStringsArray | string,
+      ...args: Array<NixStrLitInterpolatable>
+    ) {
+      const cmdToExecute =
+        typeof s === "string" ? nixStrLit(s) : nixStrLit(s, ...args);
       const shellEnv = nixRaw`
       let
         dev = ${this.nixExpression};

--- a/ts/project.ts
+++ b/ts/project.ts
@@ -192,7 +192,7 @@ const proxyEnvironmentHelpers = (): ProjectHelpers => ({
     if (script != null) {
       return {
         ...this,
-        ...{ [name]: this.shell(script) },
+        [name]: this.shell(script),
       };
     }
     const templateLiteralFn = (
@@ -201,7 +201,7 @@ const proxyEnvironmentHelpers = (): ProjectHelpers => ({
     ) => {
       return {
         ...this,
-        ...{ [name]: this.shell(s, ...args) },
+        [name]: this.shell(s, ...args),
       };
     };
     markAsMayNotExport(templateLiteralFn, (exportName: string) =>
@@ -226,7 +226,7 @@ const proxyEnvironmentHelpers = (): ProjectHelpers => ({
     if (check != null) {
       return {
         ...this,
-        ...{ [name]: this.check(check) },
+        [name]: this.check(check),
       };
     }
     const templateLiteralFn = (
@@ -235,7 +235,7 @@ const proxyEnvironmentHelpers = (): ProjectHelpers => ({
     ) => {
       return {
         ...this,
-        ...{ [name]: this.check(s, ...args) },
+        [name]: this.check(s, ...args),
       };
     };
     markAsMayNotExport(templateLiteralFn, (exportName: string) =>

--- a/ts/project.ts
+++ b/ts/project.ts
@@ -194,24 +194,23 @@ const proxyEnvironmentHelpers = (): ProjectHelpers => ({
         ...this,
         ...{ [name]: this.shell(script) },
       };
-    } else {
-      const templateLiteralFn = (
-        s: TemplateStringsArray,
-        ...args: Array<string>
-      ) => {
-        return {
-          ...this,
-          ...{ [name]: this.shell(s, ...args) },
-        };
-      };
-      markAsMayNotExport(templateLiteralFn, (exportName: string) =>
-        [
-          `${exportName} exports the return type of "addExecutable", but this is not the proper usage of addExecutable.`,
-          'Did you forget the template literal? Example usage: project.addExecutable("executable-name")`shell script to run`',
-        ].join(" "),
-      );
-      return templateLiteralFn;
     }
+    const templateLiteralFn = (
+      s: TemplateStringsArray,
+      ...args: Array<string>
+    ) => {
+      return {
+        ...this,
+        ...{ [name]: this.shell(s, ...args) },
+      };
+    };
+    markAsMayNotExport(templateLiteralFn, (exportName: string) =>
+      [
+        `${exportName} exports the return type of "addExecutable", but this is not the proper usage of addExecutable.`,
+        'Did you forget the template literal? Example usage: project.addExecutable("executable-name")`shell script to run`',
+      ].join(" "),
+    );
+    return templateLiteralFn;
   },
 
   addCheck<T extends Project, Name extends string>(
@@ -229,24 +228,23 @@ const proxyEnvironmentHelpers = (): ProjectHelpers => ({
         ...this,
         ...{ [name]: this.check(check) },
       };
-    } else {
-      const templateLiteralFn = (
-        s: TemplateStringsArray,
-        ...args: Array<string>
-      ) => {
-        return {
-          ...this,
-          ...{ [name]: this.check(s, ...args) },
-        };
-      };
-      markAsMayNotExport(templateLiteralFn, (exportName: string) =>
-        [
-          `${exportName} exports the return type of "addCheck", but this is not the proper usage of addCheck.`,
-          'Did you forget the template literal? Example usage: project.addCheck("check-name")`shell script to run`',
-        ].join(" "),
-      );
-      return templateLiteralFn;
     }
+    const templateLiteralFn = (
+      s: TemplateStringsArray,
+      ...args: Array<string>
+    ) => {
+      return {
+        ...this,
+        ...{ [name]: this.check(s, ...args) },
+      };
+    };
+    markAsMayNotExport(templateLiteralFn, (exportName: string) =>
+      [
+        `${exportName} exports the return type of "addCheck", but this is not the proper usage of addCheck.`,
+        'Did you forget the template literal? Example usage: project.addCheck("check-name")`shell script to run`',
+      ].join(" "),
+    );
+    return templateLiteralFn;
   },
 
   withDevTools<T extends Project>(this: T, devTools: Array<Package>): T {

--- a/ts/project.ts
+++ b/ts/project.ts
@@ -40,7 +40,7 @@ type ProjectHelpers = {
   shell(
     this: Project,
     _s: TemplateStringsArray,
-    ..._args: Array<string>
+    ..._args: Array<NixStrLitInterpolatable>
   ): Executable;
 
   /**
@@ -51,13 +51,13 @@ type ProjectHelpers = {
   check(
     this: Project,
     _s: TemplateStringsArray,
-    ..._args: Array<string>
+    ..._args: Array<NixStrLitInterpolatable>
   ): Check;
 
   build(
     this: Project,
     _s: TemplateStringsArray,
-    ..._args: Array<string>
+    ..._args: Array<NixStrLitInterpolatable>
   ): Package;
 
   /**
@@ -78,7 +78,7 @@ type ProjectHelpers = {
     name: Name,
   ): (
     _s: TemplateStringsArray,
-    ..._args: Array<string>
+    ..._args: Array<NixStrLitInterpolatable>
   ) => T & { [n in Name]: Executable };
 
   /**
@@ -100,7 +100,7 @@ type ProjectHelpers = {
     name: Name,
   ): (
     _s: TemplateStringsArray,
-    ..._args: Array<string>
+    ..._args: Array<NixStrLitInterpolatable>
   ) => T & { [n in Name]: Check };
 };
 
@@ -197,7 +197,7 @@ const proxyEnvironmentHelpers = (): ProjectHelpers => ({
     }
     const templateLiteralFn = (
       s: TemplateStringsArray,
-      ...args: Array<string>
+      ...args: Array<NixStrLitInterpolatable>
     ) => {
       return {
         ...this,
@@ -231,7 +231,7 @@ const proxyEnvironmentHelpers = (): ProjectHelpers => ({
     }
     const templateLiteralFn = (
       s: TemplateStringsArray,
-      ...args: Array<string>
+      ...args: Array<NixStrLitInterpolatable>
     ) => {
       return {
         ...this,

--- a/ts/project.ts
+++ b/ts/project.ts
@@ -190,22 +190,18 @@ const proxyEnvironmentHelpers = (): ProjectHelpers => ({
       );
     }
     if (script != null) {
-      const newExecutable = { [name]: this.shell(script) };
       return {
         ...this,
-        ...newExecutable,
+        ...{ [name]: this.shell(script) },
       };
     } else {
       const templateLiteralFn = (
         s: TemplateStringsArray,
         ...args: Array<string>
       ) => {
-        const newExecutable = { [name]: this.shell(s, ...args) } as {
-          [n in Name]: Executable;
-        };
         return {
           ...this,
-          ...newExecutable,
+          ...{ [name]: this.shell(s, ...args) },
         };
       };
       markAsMayNotExport(templateLiteralFn, (exportName: string) =>
@@ -229,20 +225,18 @@ const proxyEnvironmentHelpers = (): ProjectHelpers => ({
       );
     }
     if (check != null) {
-      const newCheck = { [name]: this.check(check) };
       return {
         ...this,
-        ...newCheck,
+        ...{ [name]: this.check(check) },
       };
     } else {
       const templateLiteralFn = (
         s: TemplateStringsArray,
         ...args: Array<string>
       ) => {
-        const newCheck = { [name]: this.check(s, ...args) };
         return {
           ...this,
-          ...newCheck,
+          ...{ [name]: this.check(s, ...args) },
         };
       };
       markAsMayNotExport(templateLiteralFn, (exportName: string) =>

--- a/website/garn.ts
+++ b/website/garn.ts
@@ -11,12 +11,12 @@ export const website = garn.javascript
     garn.mkPackage(nixRaw("pkgs.nodePackages.typescript-language-server")),
     garn.mkPackage(nixRaw("pkgs.nodePackages.prettier")),
   ])
-  .addCheck("tsc")`npm run tsc`
-  .addCheck("fmt-check")`prettier src/**/*.tsx src/**/*.ts --check`
-  .addExecutable("fmt")`prettier src/**/*.tsx src/**/*.ts --write`;
+  .addCheck("tsc", "npm run tsc")
+  .addCheck("fmt-check", "prettier src/**/*.tsx src/**/*.ts --check")
+  .addExecutable("fmt", "prettier src/**/*.tsx src/**/*.ts --write");
 
-export const dev = website.shell`npm install ; npm run dev`;
+export const dev = website.shell("npm install ; npm run dev");
 
-export const build = website.shell`npm install ; npm run build`;
+export const build = website.shell("npm install ; npm run build");
 
 export const edit = garn.editGarnConfig;

--- a/website/src/components/Hero/index.tsx
+++ b/website/src/components/Hero/index.tsx
@@ -136,12 +136,12 @@ to add a dev tool to your shell.
     <Tooltip item="addCheck">
       addCheck adds a <em>pure</em> check that you can run locally or on CI.
     </Tooltip>
-    (<String>"no-todos-allowed"</String>)<String>`! rg -i todo .`</String>
+    (<String>"no-todos-allowed"</String>, <String>"! rg -i todo ."</String>)
     <br />
     {"  "}.
     <Tooltip item="addExecutable">
       addExecutable adds a script that you can run locally with 'garn run'.
     </Tooltip>
-    (<String>"dev-server"</String>)<String>`air main.go`</String>;
+    (<String>"dev-server"</String>, <String>"air main.go"</String>);
   </>
 );

--- a/website/src/docs/concepts.mdx
+++ b/website/src/docs/concepts.mdx
@@ -84,7 +84,7 @@ Here's a small example:
 import * as garn from "https://garn.io/ts/v0.0.14/mod.ts";
 
 export const hello =
-  garn.emptyEnvironment.shell`echo Hello, world!`;
+  garn.emptyEnvironment.shell("echo Hello, world!");
 ```
 
 You can run `Executable`s with `garn run`.
@@ -135,12 +135,12 @@ export const project = garn.javascript
     description: "An Npm frontend",
     nodeVersion: "18",
   })
-  .addCheck("test")`npm run test`
-  .addCheck("tsc")`npm run tsc`
+  .addCheck("test", "npm run test")
+  .addCheck("tsc", "npm run tsc")
   .withDevTools([pkgs.ripgrep])
-  .addCheck("no todos allowed")`! rg --glob !node_modules -i todo .`;
+  .addCheck("no todos allowed", "! rg --glob !node_modules -i todo .");
 
-export const dev = project.shell`npm install ; npm run dev`;
+export const dev = project.shell("npm install ; npm run dev");
 ```
 
 With this `garn.ts` file:

--- a/website/src/docs/tutorial.mdx
+++ b/website/src/docs/tutorial.mdx
@@ -60,7 +60,7 @@ export const frontend = garn.javascript
     nodeVersion: "18",
     src: "./frontend",
   })
-  .addCheck("test")`npm test`;
+  .addCheck("test", "npm test");
 ```
 
 Now running `garn check frontend` will run `npm test` in the frontend project

--- a/website/src/pages/main.tsx
+++ b/website/src/pages/main.tsx
@@ -95,7 +95,7 @@ export const backend = garn.haskell
     src: ".",
   })
   .withDevTools([nixpkgs.hlint])
-  .addCheck("hlint")\`hlint *.hs\`; `}
+  .addCheck("hlint", "hlint *.hs"); `}
             />
             <Code
               header="terminal"
@@ -128,7 +128,7 @@ check> No hints`}
   goVersion: "1.20",
 })
   .withDevTools([pkgs.protobuf, pkgs.protoc_gen_go])
-  .addExecutable("codegen")\`protoc --go_out=out protobufs/*.proto\`; `}
+  .addExecutable("codegen", "protoc --go_out=out protobufs/*.proto"); `}
             />
             <Code
               header="terminal"


### PR DESCRIPTION
This is a somewhat drastic change, but the new overloads feel much better than the backtick version. I *think* for now we should still support the backtick version for cases where users want to splice in packages.

Also while I *think* this is a backwards compatible change, maybe we should still bump the ts lib version? WDYT?