### PR TITLE
Update readme and monorepo example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,19 @@ export const frontend = garn.javascript.mkNpmProject({
   description: "My project frontend",
   src: "frontend",
   nodeVersion: "18",
-});
+})
+  .addExecutable("run")`cd frontend && npm install && npm start`;
 
 export const backend = garn.go.mkGoProject({
   description: "My project backend",
   src: "backend",
   goVersion: "1.20",
-});
+})
+  .addExecutable("run")`cd backend && go run ./main.go`;
 
 export const startAll = garn.processCompose({
-  frontend: frontend.devShell.shell`cd frontend && npm install && npm start`,
-  backend: backend.defaultExecutable!,
+  frontend: frontend.run,
+  backend: backend.run,
 });
 ```
 
@@ -43,7 +45,7 @@ of using e.g. docker.
 ### Install garn
 
 ```bash
-curl --proto '=https' --tlsv1.2 -sSf https://garn.io/install.sh | sh
+sh <(curl --proto '=https' --tlsv1.2 -sSf https://garn.io/install.sh)
 ```
 
 `garn` needs [`nix`](https://nixos.org/) to be installed, so -- if you don't

--- a/examples/monorepo/flake.nix
+++ b/examples/monorepo/flake.nix
@@ -263,52 +263,7 @@
           pkgs = import "${nixpkgs}" { inherit system; };
         in
         {
-          "haskell" = {
-            "type" = "app";
-            "program" = "${
-      let
-        dev = pkgs.mkShell {};
-        shell = "${
-    (pkgs.haskell.packages.ghc94.callCabal2nix
-      "garn-pkg"
-      
-  (let
-    lib = pkgs.lib;
-    lastSafe = list :
-      if lib.lists.length list == 0
-        then null
-        else lib.lists.last list;
-  in
-  builtins.path
-    {
-      path = ./haskell;
-      name = "source";
-      filter = path: type:
-        let
-          fileName = lastSafe (lib.strings.splitString "/" path);
-        in
-         fileName != "flake.nix" &&
-         fileName != "garn.ts";
-    })
-
-      { })
-      // {
-        meta.mainProgram = "helloFromHaskell";
-      }
-  }/bin/helloFromHaskell";
-        buildPath = pkgs.runCommand "build-inputs-path" {
-          inherit (dev) buildInputs nativeBuildInputs;
-        } "echo $PATH > $out";
-      in
-      pkgs.writeScript "shell-env"  ''
-        #!${pkgs.bash}/bin/bash
-        export PATH=$(cat ${buildPath}):$PATH
-        ${dev.shellHook}
-        ${shell} "$@"
-      ''
-    }";
-          };
-          "runBackend" = {
+          "backend/run" = {
             "type" = "app";
             "program" = "${
       let
@@ -365,6 +320,76 @@
         })
       ;
         shell = "cd backend && go run ./main.go";
+        buildPath = pkgs.runCommand "build-inputs-path" {
+          inherit (dev) buildInputs nativeBuildInputs;
+        } "echo $PATH > $out";
+      in
+      pkgs.writeScript "shell-env"  ''
+        #!${pkgs.bash}/bin/bash
+        export PATH=$(cat ${buildPath}):$PATH
+        ${dev.shellHook}
+        ${shell} "$@"
+      ''
+    }";
+          };
+          "haskell" = {
+            "type" = "app";
+            "program" = "${
+      let
+        dev = pkgs.mkShell {};
+        shell = "${
+    (pkgs.haskell.packages.ghc94.callCabal2nix
+      "garn-pkg"
+      
+  (let
+    lib = pkgs.lib;
+    lastSafe = list :
+      if lib.lists.length list == 0
+        then null
+        else lib.lists.last list;
+  in
+  builtins.path
+    {
+      path = ./haskell;
+      name = "source";
+      filter = path: type:
+        let
+          fileName = lastSafe (lib.strings.splitString "/" path);
+        in
+         fileName != "flake.nix" &&
+         fileName != "garn.ts";
+    })
+
+      { })
+      // {
+        meta.mainProgram = "helloFromHaskell";
+      }
+  }/bin/helloFromHaskell";
+        buildPath = pkgs.runCommand "build-inputs-path" {
+          inherit (dev) buildInputs nativeBuildInputs;
+        } "echo $PATH > $out";
+      in
+      pkgs.writeScript "shell-env"  ''
+        #!${pkgs.bash}/bin/bash
+        export PATH=$(cat ${buildPath}):$PATH
+        ${dev.shellHook}
+        ${shell} "$@"
+      ''
+    }";
+          };
+          "npmFrontend/run" = {
+            "type" = "app";
+            "program" = "${
+      let
+        dev = 
+        (pkgs.mkShell {}).overrideAttrs (finalAttrs: previousAttrs: {
+          nativeBuildInputs =
+            previousAttrs.nativeBuildInputs
+            ++
+            [pkgs.nodejs-18_x];
+        })
+      ;
+        shell = "cd frontend-npm && npm install && npm start";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";

--- a/examples/monorepo/garn.ts
+++ b/examples/monorepo/garn.ts
@@ -3,9 +3,8 @@ import * as garn from "http://localhost:8777/mod.ts";
 export const backend = garn.go.mkGoProject({
   description: "example backend server in go",
   src: "backend",
-});
-
-export const runBackend = backend.shell`cd backend && go run ./main.go`;
+})
+  .addExecutable("run")`cd backend && go run ./main.go`;
 
 export const haskell = garn.haskell.mkHaskellProject({
   description: "My haskell executable",
@@ -18,10 +17,11 @@ export const npmFrontend = garn.javascript.mkNpmProject({
   description: "frontend test app created by create-react-app",
   src: "frontend-npm",
   nodeVersion: "18",
-});
+})
+  .addExecutable("run")`cd frontend-npm && npm install && npm start`;
 
 export const startAll = garn.processCompose({
-  backend: runBackend,
+  backend: backend.run,
   haskell: haskell.defaultExecutable!,
-  frontend: npmFrontend.shell`cd frontend-npm && npm install && npm start`,
+  frontend: npmFrontend.run,
 });


### PR DESCRIPTION
The readme had a few errors that were out of date (garn.ts and install instructions), and the monorepo example was not making use of the new `addExecutable` helper.