### PR TITLE
Keep `NixExpression`s as AST until serialization

### DIFF
--- a/.golden/generates_formatted_flakes/golden
+++ b/.golden/generates_formatted_flakes/golden
@@ -20,36 +20,32 @@
           };
         in
         {
-          "foo_pkg" =
-            (pkgs.haskell.packages.ghc94.callCabal2nix
-              "garn-pkg"
-
-              (
-                let
-                  lib = pkgs.lib;
-                  lastSafe = list:
-                    if lib.lists.length list == 0
-                    then null
-                    else lib.lists.last list;
-                in
-                builtins.path
-                  {
-                    path = ./.;
-                    name = "source";
-                    filter = path: type:
-                      let
-                        fileName = lastSafe (lib.strings.splitString "/" path);
-                      in
-                      fileName != "flake.nix" &&
+          "foo_pkg" = (pkgs.haskell.packages.ghc94.callCabal2nix
+            "garn-pkg"
+            (
+              let
+                lib = pkgs.lib;
+                lastSafe = list:
+                  if lib.lists.length list == 0
+                  then null
+                  else lib.lists.last list;
+              in
+              builtins.path
+                {
+                  path = ./.;
+                  name = "source";
+                  filter = path: type:
+                    let
+                      fileName = lastSafe (lib.strings.splitString "/" path);
+                    in
+                    fileName != "flake.nix" &&
                       fileName != "garn.ts";
-                  }
-              )
-
-              { })
-            // {
-              meta.mainProgram = "garn-test";
-            }
-          ;
+                }
+            )
+            { })
+          // {
+            meta.mainProgram = "garn-test";
+          };
         }
       );
       checks = forAllSystems (system:
@@ -69,51 +65,45 @@
           };
         in
         {
-          "foo" =
-            (
-              let
-                expr =
-                  (pkgs.haskell.packages.ghc94.callCabal2nix
-                    "garn-pkg"
-
-                    (
-                      let
-                        lib = pkgs.lib;
-                        lastSafe = list:
-                          if lib.lists.length list == 0
-                          then null
-                          else lib.lists.last list;
-                      in
-                      builtins.path
-                        {
-                          path = ./.;
-                          name = "source";
-                          filter = path: type:
-                            let
-                              fileName = lastSafe (lib.strings.splitString "/" path);
-                            in
-                            fileName != "flake.nix" &&
-                            fileName != "garn.ts";
-                        }
-                    )
-
-                    { })
-                  // {
-                    meta.mainProgram = "garn-test";
-                  }
-                ;
-              in
-              (if expr ? env
-              then expr.env
-              else pkgs.mkShell { inputsFrom = [ expr ]; }
-              )
-            ).overrideAttrs (finalAttrs: previousAttrs: {
-              nativeBuildInputs =
-                previousAttrs.nativeBuildInputs
-                ++
-                [ pkgs.haskell.packages.ghc94.cabal-install ];
-            })
-          ;
+          "foo" = (
+            let
+              expr = (pkgs.haskell.packages.ghc94.callCabal2nix
+                "garn-pkg"
+                (
+                  let
+                    lib = pkgs.lib;
+                    lastSafe = list:
+                      if lib.lists.length list == 0
+                      then null
+                      else lib.lists.last list;
+                  in
+                  builtins.path
+                    {
+                      path = ./.;
+                      name = "source";
+                      filter = path: type:
+                        let
+                          fileName = lastSafe (lib.strings.splitString "/" path);
+                        in
+                        fileName != "flake.nix" &&
+                          fileName != "garn.ts";
+                    }
+                )
+                { })
+              // {
+                meta.mainProgram = "garn-test";
+              };
+            in
+            (if expr ? env
+            then expr.env
+            else pkgs.mkShell { inputsFrom = [ expr ]; }
+            )
+          ).overrideAttrs (finalAttrs: previousAttrs: {
+            nativeBuildInputs =
+              previousAttrs.nativeBuildInputs
+              ++
+              [ pkgs.haskell.packages.ghc94.cabal-install ];
+          });
         }
       );
       apps = forAllSystems (system:
@@ -123,14 +113,11 @@
         {
           "foo" = {
             "type" = "app";
-            "program" = "${
-      let
+            "program" = "${let
         dev = pkgs.mkShell {};
-        shell = "${
-    (pkgs.haskell.packages.ghc94.callCabal2nix
+        shell = "${(pkgs.haskell.packages.ghc94.callCabal2nix
       "garn-pkg"
-      
-  (let
+      (let
     lib = pkgs.lib;
     lastSafe = list :
       if lib.lists.length list == 0
@@ -148,12 +135,10 @@
          fileName != "flake.nix" &&
          fileName != "garn.ts";
     })
-
       { })
       // {
         meta.mainProgram = "garn-test";
-      }
-  }/bin/garn-test";
+      }}/bin/${"garn-test"}";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";
@@ -163,8 +148,7 @@
         export PATH=$(cat ${buildPath}):$PATH
         ${dev.shellHook}
         ${shell} "$@"
-      ''
-    }";
+      ''}";
           };
         }
       );

--- a/examples/frontend-create-react-app/flake.nix
+++ b/examples/frontend-create-react-app/flake.nix
@@ -22,14 +22,12 @@
         {
           "bundle_package" =
             let
-              dev =
-                (pkgs.mkShell { }).overrideAttrs (finalAttrs: previousAttrs: {
-                  nativeBuildInputs =
-                    previousAttrs.nativeBuildInputs
-                    ++
-                    [ pkgs.nodejs-18_x ];
-                })
-              ;
+              dev = (pkgs.mkShell { }).overrideAttrs (finalAttrs: previousAttrs: {
+                nativeBuildInputs =
+                  previousAttrs.nativeBuildInputs
+                  ++
+                  [ pkgs.nodejs-18_x ];
+              });
             in
             pkgs.runCommand "garn-pkg"
               {
@@ -39,8 +37,7 @@
       mkdir \$out
       ${"
       echo copying source
-      cp -r ${
-  (let
+      cp -r ${(let
     lib = pkgs.lib;
     lastSafe = list :
       if lib.lists.length list == 0
@@ -57,27 +54,22 @@
         in
          fileName != "flake.nix" &&
          fileName != "garn.ts";
-    })
-} src
+    })} src
       chmod -R u+rwX src
       cd src
       echo copying node_modules
-      cp -r ${
-    let
+      cp -r ${let
       npmlock2nix = import npmlock2nix-repo {
         inherit pkgs;
       };
-      pkgs = 
-      import "${nixpkgs}" {
+      pkgs = import "${nixpkgs}" {
         config.permittedInsecurePackages = [];
         inherit system;
-      }
-    ;
+      };
     in
     npmlock2nix.v2.node_modules
       {
-        src = 
-  (let
+        src = (let
     lib = pkgs.lib;
     lastSafe = list :
       if lib.lists.length list == 0
@@ -94,58 +86,50 @@
         in
          fileName != "flake.nix" &&
          fileName != "garn.ts";
-    })
-;
+    });
         nodejs = pkgs.nodejs-18_x;
-      }
-  }/node_modules .
+      }}/node_modules .
       chmod -R u+rwX node_modules
     "}
       ${"
       npm run build
       cp -rv build/* \$out
     "}
-    "
-          ;
+    ";
           "main_node_modules" =
             let
               npmlock2nix = import npmlock2nix-repo {
                 inherit pkgs;
               };
-              pkgs =
-                import "${nixpkgs}" {
-                  config.permittedInsecurePackages = [ ];
-                  inherit system;
-                }
-              ;
+              pkgs = import "${nixpkgs}" {
+                config.permittedInsecurePackages = [ ];
+                inherit system;
+              };
             in
             npmlock2nix.v2.node_modules
               {
-                src =
-                  (
-                    let
-                      lib = pkgs.lib;
-                      lastSafe = list:
-                        if lib.lists.length list == 0
-                        then null
-                        else lib.lists.last list;
-                    in
-                    builtins.path
-                      {
-                        path = ./.;
-                        name = "source";
-                        filter = path: type:
-                          let
-                            fileName = lastSafe (lib.strings.splitString "/" path);
-                          in
-                          fileName != "flake.nix" &&
-                          fileName != "garn.ts";
-                      }
-                  )
-                ;
+                src = (
+                  let
+                    lib = pkgs.lib;
+                    lastSafe = list:
+                      if lib.lists.length list == 0
+                      then null
+                      else lib.lists.last list;
+                  in
+                  builtins.path
+                    {
+                      path = ./.;
+                      name = "source";
+                      filter = path: type:
+                        let
+                          fileName = lastSafe (lib.strings.splitString "/" path);
+                        in
+                        fileName != "flake.nix" &&
+                        fileName != "garn.ts";
+                    }
+                );
                 nodejs = pkgs.nodejs-18_x;
-              }
-          ;
+              };
         }
       );
       checks = forAllSystems (system:
@@ -165,14 +149,12 @@
           };
         in
         {
-          "main" =
-            (pkgs.mkShell { }).overrideAttrs (finalAttrs: previousAttrs: {
-              nativeBuildInputs =
-                previousAttrs.nativeBuildInputs
-                ++
-                [ pkgs.nodejs-18_x ];
-            })
-          ;
+          "main" = (pkgs.mkShell { }).overrideAttrs (finalAttrs: previousAttrs: {
+            nativeBuildInputs =
+              previousAttrs.nativeBuildInputs
+              ++
+              [ pkgs.nodejs-18_x ];
+          });
         }
       );
       apps = forAllSystems (system:
@@ -182,16 +164,13 @@
         {
           "start" = {
             "type" = "app";
-            "program" = "${
-      let
-        dev = 
-        (pkgs.mkShell {}).overrideAttrs (finalAttrs: previousAttrs: {
+            "program" = "${let
+        dev = (pkgs.mkShell {}).overrideAttrs (finalAttrs: previousAttrs: {
           nativeBuildInputs =
             previousAttrs.nativeBuildInputs
             ++
             [pkgs.nodejs-18_x];
-        })
-      ;
+        });
         shell = "npm install && npm start";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
@@ -202,8 +181,7 @@
         export PATH=$(cat ${buildPath}):$PATH
         ${dev.shellHook}
         ${shell} "$@"
-      ''
-    }";
+      ''}";
           };
         }
       );

--- a/examples/frontend-yarn-webpack/flake.nix
+++ b/examples/frontend-yarn-webpack/flake.nix
@@ -22,42 +22,37 @@
         {
           "frontend_pkg" =
             let
-              pkgs =
-                import "${nixpkgs}" {
-                  config.permittedInsecurePackages = [ ];
-                  inherit system;
-                }
-              ;
+              pkgs = import "${nixpkgs}" {
+                config.permittedInsecurePackages = [ ];
+                inherit system;
+              };
               packageJson = pkgs.lib.importJSON ./package.json;
-              yarnPackage =
-                pkgs.yarn2nix-moretea.mkYarnPackage {
-                  nodejs = pkgs.nodejs-18_x;
-                  yarn = pkgs.yarn;
-                  src =
-                    (
-                      let
-                        lib = pkgs.lib;
-                        lastSafe = list:
-                          if lib.lists.length list == 0
-                          then null
-                          else lib.lists.last list;
-                      in
-                      builtins.path
-                        {
-                          path = ./.;
-                          name = "source";
-                          filter = path: type:
-                            let
-                              fileName = lastSafe (lib.strings.splitString "/" path);
-                            in
-                            fileName != "flake.nix" &&
-                            fileName != "garn.ts";
-                        }
-                    )
-                  ;
-                  buildPhase = "yarn mocha";
-                  dontStrip = true;
-                };
+              yarnPackage = pkgs.yarn2nix-moretea.mkYarnPackage {
+                nodejs = pkgs.nodejs-18_x;
+                yarn = pkgs.yarn;
+                src = (
+                  let
+                    lib = pkgs.lib;
+                    lastSafe = list:
+                      if lib.lists.length list == 0
+                      then null
+                      else lib.lists.last list;
+                  in
+                  builtins.path
+                    {
+                      path = ./.;
+                      name = "source";
+                      filter = path: type:
+                        let
+                          fileName = lastSafe (lib.strings.splitString "/" path);
+                        in
+                        fileName != "flake.nix" &&
+                        fileName != "garn.ts";
+                    }
+                );
+                buildPhase = "yarn mocha";
+                dontStrip = true;
+              };
               nodeModulesPath = "${yarnPackage}/libexec/${packageJson.name}/node_modules";
             in
             (pkgs.writeScriptBin "start-server" "
@@ -68,9 +63,8 @@
         export PATH=${pkgs.yarn}/bin:\$PATH
         export PATH=${nodeModulesPath}/.bin:\$PATH
         yarn --version
-        yarn start
-      ")
-          ;
+        ${"yarn start"}
+      ");
         }
       );
       checks = forAllSystems (system:
@@ -92,42 +86,37 @@
         {
           "frontend" =
             let
-              pkgs =
-                import "${nixpkgs}" {
-                  config.permittedInsecurePackages = [ ];
-                  inherit system;
-                }
-              ;
+              pkgs = import "${nixpkgs}" {
+                config.permittedInsecurePackages = [ ];
+                inherit system;
+              };
               packageJson = pkgs.lib.importJSON ./package.json;
-              yarnPackage =
-                pkgs.yarn2nix-moretea.mkYarnPackage {
-                  nodejs = pkgs.nodejs-18_x;
-                  yarn = pkgs.yarn;
-                  src =
-                    (
-                      let
-                        lib = pkgs.lib;
-                        lastSafe = list:
-                          if lib.lists.length list == 0
-                          then null
-                          else lib.lists.last list;
-                      in
-                      builtins.path
-                        {
-                          path = ./.;
-                          name = "source";
-                          filter = path: type:
-                            let
-                              fileName = lastSafe (lib.strings.splitString "/" path);
-                            in
-                            fileName != "flake.nix" &&
-                            fileName != "garn.ts";
-                        }
-                    )
-                  ;
-                  buildPhase = "yarn mocha";
-                  dontStrip = true;
-                };
+              yarnPackage = pkgs.yarn2nix-moretea.mkYarnPackage {
+                nodejs = pkgs.nodejs-18_x;
+                yarn = pkgs.yarn;
+                src = (
+                  let
+                    lib = pkgs.lib;
+                    lastSafe = list:
+                      if lib.lists.length list == 0
+                      then null
+                      else lib.lists.last list;
+                  in
+                  builtins.path
+                    {
+                      path = ./.;
+                      name = "source";
+                      filter = path: type:
+                        let
+                          fileName = lastSafe (lib.strings.splitString "/" path);
+                        in
+                        fileName != "flake.nix" &&
+                        fileName != "garn.ts";
+                    }
+                );
+                buildPhase = "yarn mocha";
+                dontStrip = true;
+              };
               nodeModulesPath = "${yarnPackage}/libexec/${packageJson.name}/node_modules";
             in
             pkgs.mkShell {
@@ -136,8 +125,7 @@
             export PATH=${nodeModulesPath}/.bin:\$PATH
             export NODE_PATH=${nodeModulesPath}:\$NODE_PATH
           ";
-            }
-          ;
+            };
         }
       );
       apps = forAllSystems (system:
@@ -147,23 +135,17 @@
         {
           "frontend" = {
             "type" = "app";
-            "program" = "${
-      let
-        dev = 
-      let
-          pkgs = 
-      import "${nixpkgs}" {
+            "program" = "${let
+        dev = let
+          pkgs = import "${nixpkgs}" {
         config.permittedInsecurePackages = [];
         inherit system;
-      }
-    ;
+      };
           packageJson = pkgs.lib.importJSON ./package.json;
-          yarnPackage = 
-    pkgs.yarn2nix-moretea.mkYarnPackage {
+          yarnPackage = pkgs.yarn2nix-moretea.mkYarnPackage {
       nodejs = pkgs.nodejs-18_x;
       yarn = pkgs.yarn;
-      src = 
-  (let
+      src = (let
     lib = pkgs.lib;
     lastSafe = list :
       if lib.lists.length list == 0
@@ -180,8 +162,7 @@
         in
          fileName != "flake.nix" &&
          fileName != "garn.ts";
-    })
-;
+    });
       buildPhase = "yarn mocha";
       dontStrip = true;
     };
@@ -193,9 +174,8 @@
             export PATH=${nodeModulesPath}/.bin:\$PATH
             export NODE_PATH=${nodeModulesPath}:\$NODE_PATH
           ";
-        }
-    ;
-        shell = "cd . && yarn start";
+        };
+        shell = "cd ${"."} && ${"yarn start"}";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";
@@ -205,28 +185,21 @@
         export PATH=$(cat ${buildPath}):$PATH
         ${dev.shellHook}
         ${shell} "$@"
-      ''
-    }";
+      ''}";
           };
           "frontend/startDev" = {
             "type" = "app";
-            "program" = "${
-      let
-        dev = 
-      let
-          pkgs = 
-      import "${nixpkgs}" {
+            "program" = "${let
+        dev = let
+          pkgs = import "${nixpkgs}" {
         config.permittedInsecurePackages = [];
         inherit system;
-      }
-    ;
+      };
           packageJson = pkgs.lib.importJSON ./package.json;
-          yarnPackage = 
-    pkgs.yarn2nix-moretea.mkYarnPackage {
+          yarnPackage = pkgs.yarn2nix-moretea.mkYarnPackage {
       nodejs = pkgs.nodejs-18_x;
       yarn = pkgs.yarn;
-      src = 
-  (let
+      src = (let
     lib = pkgs.lib;
     lastSafe = list :
       if lib.lists.length list == 0
@@ -243,8 +216,7 @@
         in
          fileName != "flake.nix" &&
          fileName != "garn.ts";
-    })
-;
+    });
       buildPhase = "yarn mocha";
       dontStrip = true;
     };
@@ -256,9 +228,8 @@
             export PATH=${nodeModulesPath}/.bin:\$PATH
             export NODE_PATH=${nodeModulesPath}:\$NODE_PATH
           ";
-        }
-    ;
-        shell = "cd . && yarn start";
+        };
+        shell = "cd ${"."} && ${"yarn start"}";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";
@@ -268,8 +239,7 @@
         export PATH=$(cat ${buildPath}):$PATH
         ${dev.shellHook}
         ${shell} "$@"
-      ''
-    }";
+      ''}";
           };
         }
       );

--- a/examples/go-http-backend/flake.nix
+++ b/examples/go-http-backend/flake.nix
@@ -35,31 +35,28 @@
               pname = "go-package";
               version = "0.1";
               go = pkgs.go_1_20;
-              src =
-                (
-                  let
-                    lib = pkgs.lib;
-                    lastSafe = list:
-                      if lib.lists.length list == 0
-                      then null
-                      else lib.lists.last list;
-                  in
-                  builtins.path
-                    {
-                      path = ./.;
-                      name = "source";
-                      filter = path: type:
-                        let
-                          fileName = lastSafe (lib.strings.splitString "/" path);
-                        in
-                        fileName != "flake.nix" &&
-                        fileName != "garn.ts";
-                    }
-                )
-              ;
+              src = (
+                let
+                  lib = pkgs.lib;
+                  lastSafe = list:
+                    if lib.lists.length list == 0
+                    then null
+                    else lib.lists.last list;
+                in
+                builtins.path
+                  {
+                    path = ./.;
+                    name = "source";
+                    filter = path: type:
+                      let
+                        fileName = lastSafe (lib.strings.splitString "/" path);
+                      in
+                      fileName != "flake.nix" &&
+                      fileName != "garn.ts";
+                  }
+              );
               modules = gomod2nix-toml;
-            }
-          ;
+            };
         }
       );
       checks = forAllSystems (system:
@@ -79,61 +76,56 @@
           };
         in
         {
-          "server" =
-            (
-              let
-                expr =
-                  let
-                    gomod2nix = gomod2nix-repo.legacyPackages.${system};
-                    gomod2nix-toml = pkgs.writeText "gomod2nix-toml" "schema = 3
+          "server" = (
+            let
+              expr =
+                let
+                  gomod2nix = gomod2nix-repo.legacyPackages.${system};
+                  gomod2nix-toml = pkgs.writeText "gomod2nix-toml" "schema = 3
 
 [mod]
   [mod.\"github.com/gorilla/mux\"]
     version = \"v1.8.0\"
     hash = \"sha256-s905hpzMH9bOLue09E2JmzPXfIS4HhAlgT7g13HCwKE=\"
 ";
-                  in
-                  gomod2nix.buildGoApplication {
-                    pname = "go-package";
-                    version = "0.1";
-                    go = pkgs.go_1_20;
-                    src =
-                      (
-                        let
-                          lib = pkgs.lib;
-                          lastSafe = list:
-                            if lib.lists.length list == 0
-                            then null
-                            else lib.lists.last list;
-                        in
-                        builtins.path
-                          {
-                            path = ./.;
-                            name = "source";
-                            filter = path: type:
-                              let
-                                fileName = lastSafe (lib.strings.splitString "/" path);
-                              in
-                              fileName != "flake.nix" &&
-                              fileName != "garn.ts";
-                          }
-                      )
-                    ;
-                    modules = gomod2nix-toml;
-                  }
-                ;
-              in
-              (if expr ? env
-              then expr.env
-              else pkgs.mkShell { inputsFrom = [ expr ]; }
-              )
-            ).overrideAttrs (finalAttrs: previousAttrs: {
-              nativeBuildInputs =
-                previousAttrs.nativeBuildInputs
-                ++
-                [ pkgs.gopls ];
-            })
-          ;
+                in
+                gomod2nix.buildGoApplication {
+                  pname = "go-package";
+                  version = "0.1";
+                  go = pkgs.go_1_20;
+                  src = (
+                    let
+                      lib = pkgs.lib;
+                      lastSafe = list:
+                        if lib.lists.length list == 0
+                        then null
+                        else lib.lists.last list;
+                    in
+                    builtins.path
+                      {
+                        path = ./.;
+                        name = "source";
+                        filter = path: type:
+                          let
+                            fileName = lastSafe (lib.strings.splitString "/" path);
+                          in
+                          fileName != "flake.nix" &&
+                          fileName != "garn.ts";
+                      }
+                  );
+                  modules = gomod2nix-toml;
+                };
+            in
+            (if expr ? env
+            then expr.env
+            else pkgs.mkShell { inputsFrom = [ expr ]; }
+            )
+          ).overrideAttrs (finalAttrs: previousAttrs: {
+            nativeBuildInputs =
+              previousAttrs.nativeBuildInputs
+              ++
+              [ pkgs.gopls ];
+          });
         }
       );
       apps = forAllSystems (system:
@@ -143,12 +135,8 @@
         {
           "server/migrate" = {
             "type" = "app";
-            "program" = "${
-      let
-        dev = 
-        (
-    let expr = 
-      let
+            "program" = "${let
+        dev = (let expr = let
         gomod2nix = gomod2nix-repo.legacyPackages.${system};
         gomod2nix-toml = pkgs.writeText "gomod2nix-toml" "schema = 3
 
@@ -162,8 +150,7 @@
           pname = "go-package";
           version = "0.1";
           go = pkgs.go_1_20;
-          src = 
-  (let
+          src = (let
     lib = pkgs.lib;
     lastSafe = list :
       if lib.lists.length list == 0
@@ -180,23 +167,19 @@
         in
          fileName != "flake.nix" &&
          fileName != "garn.ts";
-    })
-;
+    });
           modules = gomod2nix-toml;
-        }
-    ;
+        };
     in
       (if expr ? env
         then expr.env
         else pkgs.mkShell { inputsFrom = [ expr ]; }
-      )
-    ).overrideAttrs (finalAttrs: previousAttrs: {
+      )).overrideAttrs (finalAttrs: previousAttrs: {
           nativeBuildInputs =
             previousAttrs.nativeBuildInputs
             ++
             [pkgs.gopls];
-        })
-      ;
+        });
         shell = "go run ./scripts/migrate.go";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
@@ -207,17 +190,12 @@
         export PATH=$(cat ${buildPath}):$PATH
         ${dev.shellHook}
         ${shell} "$@"
-      ''
-    }";
+      ''}";
           };
           "server/dev" = {
             "type" = "app";
-            "program" = "${
-      let
-        dev = 
-        (
-    let expr = 
-      let
+            "program" = "${let
+        dev = (let expr = let
         gomod2nix = gomod2nix-repo.legacyPackages.${system};
         gomod2nix-toml = pkgs.writeText "gomod2nix-toml" "schema = 3
 
@@ -231,8 +209,7 @@
           pname = "go-package";
           version = "0.1";
           go = pkgs.go_1_20;
-          src = 
-  (let
+          src = (let
     lib = pkgs.lib;
     lastSafe = list :
       if lib.lists.length list == 0
@@ -249,23 +226,19 @@
         in
          fileName != "flake.nix" &&
          fileName != "garn.ts";
-    })
-;
+    });
           modules = gomod2nix-toml;
-        }
-    ;
+        };
     in
       (if expr ? env
         then expr.env
         else pkgs.mkShell { inputsFrom = [ expr ]; }
-      )
-    ).overrideAttrs (finalAttrs: previousAttrs: {
+      )).overrideAttrs (finalAttrs: previousAttrs: {
           nativeBuildInputs =
             previousAttrs.nativeBuildInputs
             ++
             [pkgs.gopls];
-        })
-      ;
+        });
         shell = "go run ./main.go";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
@@ -276,8 +249,7 @@
         export PATH=$(cat ${buildPath}):$PATH
         ${dev.shellHook}
         ${shell} "$@"
-      ''
-    }";
+      ''}";
           };
         }
       );

--- a/examples/haskell/flake.nix
+++ b/examples/haskell/flake.nix
@@ -20,36 +20,32 @@
           };
         in
         {
-          "helloFromHaskell_pkg" =
-            (pkgs.haskell.packages.ghc94.callCabal2nix
-              "garn-pkg"
-
-              (
-                let
-                  lib = pkgs.lib;
-                  lastSafe = list:
-                    if lib.lists.length list == 0
-                    then null
-                    else lib.lists.last list;
-                in
-                builtins.path
-                  {
-                    path = ./.;
-                    name = "source";
-                    filter = path: type:
-                      let
-                        fileName = lastSafe (lib.strings.splitString "/" path);
-                      in
-                      fileName != "flake.nix" &&
+          "helloFromHaskell_pkg" = (pkgs.haskell.packages.ghc94.callCabal2nix
+            "garn-pkg"
+            (
+              let
+                lib = pkgs.lib;
+                lastSafe = list:
+                  if lib.lists.length list == 0
+                  then null
+                  else lib.lists.last list;
+              in
+              builtins.path
+                {
+                  path = ./.;
+                  name = "source";
+                  filter = path: type:
+                    let
+                      fileName = lastSafe (lib.strings.splitString "/" path);
+                    in
+                    fileName != "flake.nix" &&
                       fileName != "garn.ts";
-                  }
-              )
-
-              { })
-            // {
-              meta.mainProgram = "helloFromHaskell";
-            }
-          ;
+                }
+            )
+            { })
+          // {
+            meta.mainProgram = "helloFromHaskell";
+          };
         }
       );
       checks = forAllSystems (system:
@@ -62,136 +58,34 @@
         {
           "helloFromHaskell_hlint" =
             let
-              dev =
-                (
-                  (
-                    let
-                      expr =
-                        (pkgs.haskell.packages.ghc94.callCabal2nix
-                          "garn-pkg"
-
-                          (
-                            let
-                              lib = pkgs.lib;
-                              lastSafe = list:
-                                if lib.lists.length list == 0
-                                then null
-                                else lib.lists.last list;
-                            in
-                            builtins.path
-                              {
-                                path = ./.;
-                                name = "source";
-                                filter = path: type:
-                                  let
-                                    fileName = lastSafe (lib.strings.splitString "/" path);
-                                  in
-                                  fileName != "flake.nix" &&
-                                  fileName != "garn.ts";
-                              }
-                          )
-
-                          { })
-                        // {
-                          meta.mainProgram = "helloFromHaskell";
-                        }
-                      ;
-                    in
-                    (if expr ? env
-                    then expr.env
-                    else pkgs.mkShell { inputsFrom = [ expr ]; }
-                    )
-                  ).overrideAttrs (finalAttrs: previousAttrs: {
-                    nativeBuildInputs =
-                      previousAttrs.nativeBuildInputs
-                      ++
-                      [ pkgs.haskell.packages.ghc94.cabal-install ];
-                  })
-                ).overrideAttrs (finalAttrs: previousAttrs: {
-                  nativeBuildInputs =
-                    previousAttrs.nativeBuildInputs
-                    ++
-                    [ pkgs.hlint ];
-                })
-              ;
-            in
-            pkgs.runCommand "check"
-              {
-                buildInputs = dev.buildInputs ++ dev.nativeBuildInputs;
-              } "
-      touch \$out
-      ${"
-      echo copying source
-      cp -r ${
-  (let
-    lib = pkgs.lib;
-    lastSafe = list :
-      if lib.lists.length list == 0
-        then null
-        else lib.lists.last list;
-  in
-  builtins.path
-    {
-      path = ./.;
-      name = "source";
-      filter = path: type:
-        let
-          fileName = lastSafe (lib.strings.splitString "/" path);
-        in
-         fileName != "flake.nix" &&
-         fileName != "garn.ts";
-    })
-} src
-      chmod -R u+rwX src
-      cd src
-    "}
-      ${"hlint *.hs"}
-    "
-          ;
-        }
-      );
-      devShells = forAllSystems (system:
-        let
-          pkgs = import "${nixpkgs}" {
-            config.allowUnfree = true;
-            inherit system;
-          };
-        in
-        {
-          "helloFromHaskell" =
-            (
-              (
+              dev = ((
                 let
-                  expr =
-                    (pkgs.haskell.packages.ghc94.callCabal2nix
-                      "garn-pkg"
-
-                      (
-                        let
-                          lib = pkgs.lib;
-                          lastSafe = list:
-                            if lib.lists.length list == 0
-                            then null
-                            else lib.lists.last list;
-                        in
-                        builtins.path
-                          {
-                            path = ./.;
-                            name = "source";
-                            filter = path: type:
-                              let
-                                fileName = lastSafe (lib.strings.splitString "/" path);
-                              in
-                              fileName != "flake.nix" &&
+                  expr = (pkgs.haskell.packages.ghc94.callCabal2nix
+                    "garn-pkg"
+                    (
+                      let
+                        lib = pkgs.lib;
+                        lastSafe = list:
+                          if lib.lists.length list == 0
+                          then null
+                          else lib.lists.last list;
+                      in
+                      builtins.path
+                        {
+                          path = ./.;
+                          name = "source";
+                          filter = path: type:
+                            let
+                              fileName = lastSafe (lib.strings.splitString "/" path);
+                            in
+                            fileName != "flake.nix" &&
                               fileName != "garn.ts";
-                          }
-                      )
-
-                      { })
-                    // {
-                      meta.mainProgram = "helloFromHaskell";
-                    }
-                  ;
+                        }
+                    )
+                    { })
+                  // {
+                    meta.mainProgram = "helloFromHaskell";
+                  };
                 in
                 (if expr ? env
                 then expr.env
@@ -202,14 +96,97 @@
                   previousAttrs.nativeBuildInputs
                   ++
                   [ pkgs.haskell.packages.ghc94.cabal-install ];
-              })
-            ).overrideAttrs (finalAttrs: previousAttrs: {
-              nativeBuildInputs =
-                previousAttrs.nativeBuildInputs
-                ++
-                [ pkgs.hlint ];
-            })
-          ;
+              })).overrideAttrs (finalAttrs: previousAttrs: {
+                nativeBuildInputs =
+                  previousAttrs.nativeBuildInputs
+                  ++
+                  [ pkgs.hlint ];
+              });
+            in
+            pkgs.runCommand "check"
+              {
+                buildInputs = dev.buildInputs ++ dev.nativeBuildInputs;
+              } "
+      touch \$out
+      ${"
+      echo copying source
+      cp -r ${(let
+    lib = pkgs.lib;
+    lastSafe = list :
+      if lib.lists.length list == 0
+        then null
+        else lib.lists.last list;
+  in
+  builtins.path
+    {
+      path = ./.;
+      name = "source";
+      filter = path: type:
+        let
+          fileName = lastSafe (lib.strings.splitString "/" path);
+        in
+         fileName != "flake.nix" &&
+         fileName != "garn.ts";
+    })} src
+      chmod -R u+rwX src
+      cd src
+    "}
+      ${"hlint *.hs"}
+    ";
+        }
+      );
+      devShells = forAllSystems (system:
+        let
+          pkgs = import "${nixpkgs}" {
+            config.allowUnfree = true;
+            inherit system;
+          };
+        in
+        {
+          "helloFromHaskell" = ((
+            let
+              expr = (pkgs.haskell.packages.ghc94.callCabal2nix
+                "garn-pkg"
+                (
+                  let
+                    lib = pkgs.lib;
+                    lastSafe = list:
+                      if lib.lists.length list == 0
+                      then null
+                      else lib.lists.last list;
+                  in
+                  builtins.path
+                    {
+                      path = ./.;
+                      name = "source";
+                      filter = path: type:
+                        let
+                          fileName = lastSafe (lib.strings.splitString "/" path);
+                        in
+                        fileName != "flake.nix" &&
+                          fileName != "garn.ts";
+                    }
+                )
+                { })
+              // {
+                meta.mainProgram = "helloFromHaskell";
+              };
+            in
+            (if expr ? env
+            then expr.env
+            else pkgs.mkShell { inputsFrom = [ expr ]; }
+            )
+          ).overrideAttrs (finalAttrs: previousAttrs: {
+            nativeBuildInputs =
+              previousAttrs.nativeBuildInputs
+              ++
+              [ pkgs.haskell.packages.ghc94.cabal-install ];
+          })).overrideAttrs (finalAttrs: previousAttrs: {
+            nativeBuildInputs =
+              previousAttrs.nativeBuildInputs
+              ++
+              [ pkgs.hlint ];
+          });
         }
       );
       apps = forAllSystems (system:
@@ -219,14 +196,11 @@
         {
           "helloFromHaskell" = {
             "type" = "app";
-            "program" = "${
-      let
+            "program" = "${let
         dev = pkgs.mkShell {};
-        shell = "${
-    (pkgs.haskell.packages.ghc94.callCabal2nix
+        shell = "${(pkgs.haskell.packages.ghc94.callCabal2nix
       "garn-pkg"
-      
-  (let
+      (let
     lib = pkgs.lib;
     lastSafe = list :
       if lib.lists.length list == 0
@@ -244,12 +218,10 @@
          fileName != "flake.nix" &&
          fileName != "garn.ts";
     })
-
       { })
       // {
         meta.mainProgram = "helloFromHaskell";
-      }
-  }/bin/helloFromHaskell";
+      }}/bin/${"helloFromHaskell"}";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";
@@ -259,8 +231,7 @@
         export PATH=$(cat ${buildPath}):$PATH
         ${dev.shellHook}
         ${shell} "$@"
-      ''
-    }";
+      ''}";
           };
         }
       );

--- a/examples/npm-project/flake.nix
+++ b/examples/npm-project/flake.nix
@@ -25,40 +25,35 @@
               npmlock2nix = import npmlock2nix-repo {
                 inherit pkgs;
               };
-              pkgs =
-                import "${nixpkgs}" {
-                  config.permittedInsecurePackages = [ ];
-                  inherit system;
-                }
-              ;
+              pkgs = import "${nixpkgs}" {
+                config.permittedInsecurePackages = [ ];
+                inherit system;
+              };
             in
             npmlock2nix.v2.node_modules
               {
-                src =
-                  (
-                    let
-                      lib = pkgs.lib;
-                      lastSafe = list:
-                        if lib.lists.length list == 0
-                        then null
-                        else lib.lists.last list;
-                    in
-                    builtins.path
-                      {
-                        path = ./.;
-                        name = "source";
-                        filter = path: type:
-                          let
-                            fileName = lastSafe (lib.strings.splitString "/" path);
-                          in
-                          fileName != "flake.nix" &&
-                          fileName != "garn.ts";
-                      }
-                  )
-                ;
+                src = (
+                  let
+                    lib = pkgs.lib;
+                    lastSafe = list:
+                      if lib.lists.length list == 0
+                      then null
+                      else lib.lists.last list;
+                  in
+                  builtins.path
+                    {
+                      path = ./.;
+                      name = "source";
+                      filter = path: type:
+                        let
+                          fileName = lastSafe (lib.strings.splitString "/" path);
+                        in
+                        fileName != "flake.nix" &&
+                        fileName != "garn.ts";
+                    }
+                );
                 nodejs = pkgs.nodejs-18_x;
-              }
-          ;
+              };
         }
       );
       checks = forAllSystems (system:
@@ -71,14 +66,12 @@
         {
           "project_test" =
             let
-              dev =
-                (pkgs.mkShell { }).overrideAttrs (finalAttrs: previousAttrs: {
-                  nativeBuildInputs =
-                    previousAttrs.nativeBuildInputs
-                    ++
-                    [ pkgs.nodejs-18_x ];
-                })
-              ;
+              dev = (pkgs.mkShell { }).overrideAttrs (finalAttrs: previousAttrs: {
+                nativeBuildInputs =
+                  previousAttrs.nativeBuildInputs
+                  ++
+                  [ pkgs.nodejs-18_x ];
+              });
             in
             pkgs.runCommand "check"
               {
@@ -87,8 +80,7 @@
       touch \$out
       ${"
       echo copying source
-      cp -r ${
-  (let
+      cp -r ${(let
     lib = pkgs.lib;
     lastSafe = list :
       if lib.lists.length list == 0
@@ -105,27 +97,22 @@
         in
          fileName != "flake.nix" &&
          fileName != "garn.ts";
-    })
-} src
+    })} src
       chmod -R u+rwX src
       cd src
       echo copying node_modules
-      cp -r ${
-    let
+      cp -r ${let
       npmlock2nix = import npmlock2nix-repo {
         inherit pkgs;
       };
-      pkgs = 
-      import "${nixpkgs}" {
+      pkgs = import "${nixpkgs}" {
         config.permittedInsecurePackages = [];
         inherit system;
-      }
-    ;
+      };
     in
     npmlock2nix.v2.node_modules
       {
-        src = 
-  (let
+        src = (let
     lib = pkgs.lib;
     lastSafe = list :
       if lib.lists.length list == 0
@@ -142,26 +129,21 @@
         in
          fileName != "flake.nix" &&
          fileName != "garn.ts";
-    })
-;
+    });
         nodejs = pkgs.nodejs-18_x;
-      }
-  }/node_modules .
+      }}/node_modules .
       chmod -R u+rwX node_modules
     "}
       ${"npm run test"}
-    "
-          ;
+    ";
           "project_tsc" =
             let
-              dev =
-                (pkgs.mkShell { }).overrideAttrs (finalAttrs: previousAttrs: {
-                  nativeBuildInputs =
-                    previousAttrs.nativeBuildInputs
-                    ++
-                    [ pkgs.nodejs-18_x ];
-                })
-              ;
+              dev = (pkgs.mkShell { }).overrideAttrs (finalAttrs: previousAttrs: {
+                nativeBuildInputs =
+                  previousAttrs.nativeBuildInputs
+                  ++
+                  [ pkgs.nodejs-18_x ];
+              });
             in
             pkgs.runCommand "check"
               {
@@ -170,8 +152,7 @@
       touch \$out
       ${"
       echo copying source
-      cp -r ${
-  (let
+      cp -r ${(let
     lib = pkgs.lib;
     lastSafe = list :
       if lib.lists.length list == 0
@@ -188,27 +169,22 @@
         in
          fileName != "flake.nix" &&
          fileName != "garn.ts";
-    })
-} src
+    })} src
       chmod -R u+rwX src
       cd src
       echo copying node_modules
-      cp -r ${
-    let
+      cp -r ${let
       npmlock2nix = import npmlock2nix-repo {
         inherit pkgs;
       };
-      pkgs = 
-      import "${nixpkgs}" {
+      pkgs = import "${nixpkgs}" {
         config.permittedInsecurePackages = [];
         inherit system;
-      }
-    ;
+      };
     in
     npmlock2nix.v2.node_modules
       {
-        src = 
-  (let
+        src = (let
     lib = pkgs.lib;
     lastSafe = list :
       if lib.lists.length list == 0
@@ -225,16 +201,13 @@
         in
          fileName != "flake.nix" &&
          fileName != "garn.ts";
-    })
-;
+    });
         nodejs = pkgs.nodejs-18_x;
-      }
-  }/node_modules .
+      }}/node_modules .
       chmod -R u+rwX node_modules
     "}
       ${"npm run tsc"}
-    "
-          ;
+    ";
         }
       );
       devShells = forAllSystems (system:
@@ -245,14 +218,12 @@
           };
         in
         {
-          "project" =
-            (pkgs.mkShell { }).overrideAttrs (finalAttrs: previousAttrs: {
-              nativeBuildInputs =
-                previousAttrs.nativeBuildInputs
-                ++
-                [ pkgs.nodejs-18_x ];
-            })
-          ;
+          "project" = (pkgs.mkShell { }).overrideAttrs (finalAttrs: previousAttrs: {
+            nativeBuildInputs =
+              previousAttrs.nativeBuildInputs
+              ++
+              [ pkgs.nodejs-18_x ];
+          });
         }
       );
       apps = forAllSystems (system:
@@ -262,16 +233,13 @@
         {
           "run" = {
             "type" = "app";
-            "program" = "${
-      let
-        dev = 
-        (pkgs.mkShell {}).overrideAttrs (finalAttrs: previousAttrs: {
+            "program" = "${let
+        dev = (pkgs.mkShell {}).overrideAttrs (finalAttrs: previousAttrs: {
           nativeBuildInputs =
             previousAttrs.nativeBuildInputs
             ++
             [pkgs.nodejs-18_x];
-        })
-      ;
+        });
         shell = "npm install ; npm run run";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
@@ -282,8 +250,7 @@
         export PATH=$(cat ${buildPath}):$PATH
         ${dev.shellHook}
         ${shell} "$@"
-      ''
-    }";
+      ''}";
           };
         }
       );

--- a/ts/environment.ts
+++ b/ts/environment.ts
@@ -7,6 +7,7 @@ import {
   nixList,
   nixRaw,
   nixStrLit,
+  toHumanReadable,
 } from "./nix.ts";
 import { Package, mkPackage } from "./package.ts";
 
@@ -168,7 +169,7 @@ export function mkEnvironment(
     `;
       return {
         tag: "executable",
-        description: `Executes ${cmdToExecute.rawNixExpressionString}`,
+        description: `Executes ${toHumanReadable(cmdToExecute)}`,
         nixExpression: nixStrLit`${shellEnv}`,
       };
     },

--- a/ts/internal/interpolatedString.ts
+++ b/ts/internal/interpolatedString.ts
@@ -1,0 +1,73 @@
+/**
+ * Represents a string with `T`s interspersed throughout the string.
+ *
+ * This is a more safe data structure than joining a `TemplateStringsArray`
+ * with a `T[]` (which is what tag template functions give you) since it
+ * enforces that given N strings, there will always be N-1 interpolations.
+ *
+ * Example:
+ * ```typescript
+ * // Given:
+ * myTemplateFn`foo${1}bar${2}baz`
+ *
+ * function myTemplateFn(s: TemplateStringsArray, ...i: Array<number>) {
+ *   // s is ["foo", "bar", "baz"]
+ *   // i is [1, 2]
+ *   // but nothing at the type level enforces that s.length - 1 == i.length
+ *
+ *   // Using `interpolatedStringFromTemplate` we can convert to a safer `InterpolatedString`:
+ *   const interpolatedString = interpolatedStringFromTemplate(s, i);
+ *   // interpolatedString is { initial: "foo", rest: [[1, "bar"], [2, "baz"]] }
+ * }
+ * ```
+ */
+export type InterpolatedString<T> = {
+  initial: string;
+  rest: Array<[T, string]>;
+};
+
+/**
+ * Converts tag template function parameters into `InterpolatedString`s
+ */
+export function interpolatedStringFromTemplate<T>(
+  s: TemplateStringsArray,
+  interpolations: Array<T>,
+): InterpolatedString<T> {
+  return {
+    initial: s[0],
+    rest: s.slice(1).map((part, i) => [interpolations[i], part]),
+  };
+}
+
+/**
+ * Convenience function to create an `InterpolatedString` with only an
+ * `initial` (no interpolations).
+ */
+export function interpolatedStringFromString(
+  s: string,
+): InterpolatedString<never> {
+  return {
+    initial: s,
+    rest: [],
+  };
+}
+
+export function renderInterpolatedString<T>(
+  interpolated: InterpolatedString<T>,
+  render: (t: T) => string,
+): string {
+  return interpolated.rest.reduce(
+    (acc, [node, str]) => acc + render(node) + str,
+    interpolated.initial,
+  );
+}
+
+export function mapStrings<T>(
+  f: (s: string) => string,
+  interpolated: InterpolatedString<T>,
+): InterpolatedString<T> {
+  return {
+    initial: f(interpolated.initial),
+    rest: interpolated.rest.map(([node, str]) => [node, f(str)]),
+  };
+}

--- a/ts/internal/runner.ts
+++ b/ts/internal/runner.ts
@@ -13,7 +13,7 @@ import {
   NixExpression,
   nixRaw,
   nixStrLit,
-  toNixString,
+  renderNixExpression,
 } from "../nix.ts";
 import { Executable } from "../mod.ts";
 import { isExecutable } from "../executable.ts";
@@ -57,7 +57,7 @@ export const toDenoOutput = (
       tag: "Success",
       contents: {
         targets: toTargets(garnExports),
-        flakeFile: toNixString(formatFlake(nixpkgsInput, garnExports)),
+        flakeFile: renderNixExpression(formatFlake(nixpkgsInput, garnExports)),
       },
     };
   } catch (err: unknown) {

--- a/ts/internal/runner.ts
+++ b/ts/internal/runner.ts
@@ -8,7 +8,13 @@ import {
   mapValues,
 } from "./utils.ts";
 import { GOMOD2NIX_REPO } from "../go/consts.ts";
-import { nixAttrSet, NixExpression, nixRaw, nixStrLit } from "../nix.ts";
+import {
+  nixAttrSet,
+  NixExpression,
+  nixRaw,
+  nixStrLit,
+  toNixString,
+} from "../nix.ts";
 import { Executable } from "../mod.ts";
 import { isExecutable } from "../executable.ts";
 import { assertMayExport } from "./may_not_export.ts";
@@ -51,8 +57,7 @@ export const toDenoOutput = (
       tag: "Success",
       contents: {
         targets: toTargets(garnExports),
-        flakeFile: formatFlake(nixpkgsInput, garnExports)
-          .rawNixExpressionString,
+        flakeFile: toNixString(formatFlake(nixpkgsInput, garnExports)),
       },
     };
   } catch (err: unknown) {

--- a/ts/internal/utils.ts
+++ b/ts/internal/utils.ts
@@ -59,6 +59,16 @@ export const mapValues = <T, R>(
   return result;
 };
 
+export const filterNullValues = <T>(
+  x: Record<string, T>,
+): Record<string, NonNullable<T>> => {
+  const result: Record<string, NonNullable<T>> = {};
+  for (const [key, value] of Object.entries(x)) {
+    if (value != null) result[key] = value;
+  }
+  return result;
+};
+
 export const checkExhaustiveness = (x: never): never => {
   throw new Error(`Exhaustiveness check failed: ${x}`);
 };

--- a/ts/nix.test.ts
+++ b/ts/nix.test.ts
@@ -30,13 +30,16 @@ Deno.test("nixStrLit correctly serializes into a nix expression", () => {
   );
 });
 
-Deno.test("toHumanReadable snips out incedental dependencies in string literals", () => {
-  assertEquals(toHumanReadable(nixStrLit`foo`), "foo");
-  assertEquals(
-    toHumanReadable(nixStrLit`foo ${nixRaw`some-nix`} bar`),
-    "foo [...] bar",
-  );
-});
+Deno.test(
+  "toHumanReadable snips out incedental dependencies in string literals",
+  () => {
+    assertEquals(toHumanReadable(nixStrLit`foo`), "foo");
+    assertEquals(
+      toHumanReadable(nixStrLit`foo ${nixRaw`some-nix`} bar`),
+      "foo [...] bar",
+    );
+  },
+);
 
 Deno.test("nixList", () => {
   assertEquals(
@@ -47,11 +50,13 @@ Deno.test("nixList", () => {
 
 Deno.test("nixAttrSet", () => {
   assertEquals(
-    toNixString(nixAttrSet({
-      a: nixRaw`1`,
-      b: nixRaw`2`,
-      c: undefined,
-    })),
+    toNixString(
+      nixAttrSet({
+        a: nixRaw`1`,
+        b: nixRaw`2`,
+        c: undefined,
+      }),
+    ),
     '{ "a" = 1; "b" = 2; }',
   );
 });

--- a/ts/nix.test.ts
+++ b/ts/nix.test.ts
@@ -5,27 +5,27 @@ import {
   nixRaw,
   nixStrLit,
   toHumanReadable,
-  toNixString,
+  renderNixExpression,
 } from "./nix.ts";
 
 Deno.test("nixStrLit correctly serializes into a nix expression", () => {
-  assertEquals(toNixString(nixStrLit`foo`), '"foo"');
+  assertEquals(renderNixExpression(nixStrLit`foo`), '"foo"');
   assertEquals(
-    toNixString(nixStrLit`with ${"string"} interpolation`),
+    renderNixExpression(nixStrLit`with ${"string"} interpolation`),
     '"with ${"string"} interpolation"',
   );
   assertEquals(
-    toNixString(nixStrLit`with package ${nixRaw`pkgs.hello`} works`),
+    renderNixExpression(nixStrLit`with package ${nixRaw`pkgs.hello`} works`),
     '"with package ${pkgs.hello} works"',
   );
   assertEquals(
-    toNixString(
+    renderNixExpression(
       nixStrLit`escaped dollars in strings \${should not interpolate}`,
     ),
     '"escaped dollars in strings \\${should not interpolate}"',
   );
   assertEquals(
-    toNixString(nixStrLit`"double quotes" are correctly escaped`),
+    renderNixExpression(nixStrLit`"double quotes" are correctly escaped`),
     '"\\"double quotes\\" are correctly escaped"',
   );
 });
@@ -43,14 +43,14 @@ Deno.test(
 
 Deno.test("nixList", () => {
   assertEquals(
-    toNixString(nixList([nixStrLit`a`, nixStrLit`b`, nixStrLit`c`])),
+    renderNixExpression(nixList([nixStrLit`a`, nixStrLit`b`, nixStrLit`c`])),
     '["a" "b" "c"]',
   );
 });
 
 Deno.test("nixAttrSet", () => {
   assertEquals(
-    toNixString(
+    renderNixExpression(
       nixAttrSet({
         a: nixRaw`1`,
         b: nixRaw`2`,

--- a/ts/nix.ts
+++ b/ts/nix.ts
@@ -34,11 +34,21 @@ export type NixStrLitInterpolatable =
  *
  * It is not advised to construct this type but instead use `nixRaw` or `nixStrLit`.
  */
-export type NixExpression =
+export type NixExpression = { [__nixExpressionTag]: null } & (
   | { type: "raw"; raw: InterpolatedString<NixExpression> }
   | { type: "list"; elements: Array<NixExpression> }
   | { type: "attrSet"; elements: Record<string, NixExpression> }
-  | { type: "strLit"; str: InterpolatedString<NixExpression> };
+  | { type: "strLit"; str: InterpolatedString<NixExpression> }
+);
+
+/**
+ * Tag for `NixExpression`.
+ *
+ * This symbol is deliberately not exported, since you're not supposed to create
+ * `NixExpression`s outside of this module. Instead use helper functions from
+ * here.
+ */
+const __nixExpressionTag = Symbol("NixExpression is opaque!");
 
 /**
  * A template literal function to construct `NixExpression`s from raw strings.
@@ -74,6 +84,7 @@ export function nixRaw(
   ...interpolations: Array<NixExpression>
 ): NixExpression {
   return {
+    [__nixExpressionTag]: null,
     type: "raw",
     raw:
       typeof s === "string"
@@ -97,6 +108,7 @@ export function nixRaw(
  */
 export function nixList(elements: Array<NixExpression>): NixExpression {
   return {
+    [__nixExpressionTag]: null,
     type: "list",
     elements: elements,
   };
@@ -120,6 +132,7 @@ export function nixAttrSet(
   attrSet: Record<string, NixExpression | undefined>,
 ): NixExpression {
   return {
+    [__nixExpressionTag]: null,
     type: "attrSet",
     elements: filterNullValues(attrSet),
   };
@@ -141,15 +154,21 @@ export function nixStrLit(
   ...interpolations: Array<NixStrLitInterpolatable>
 ): NixExpression {
   if (typeof s === "string") {
-    return { type: "strLit", str: interpolatedStringFromString(s) };
+    return {
+      [__nixExpressionTag]: null,
+      type: "strLit",
+      str: interpolatedStringFromString(s),
+    };
   }
   return {
+    [__nixExpressionTag]: null,
     type: "strLit",
     str: interpolatedStringFromTemplate(
       s,
       interpolations.map((interpolation): NixExpression => {
         if (typeof interpolation === "string") {
           return {
+            [__nixExpressionTag]: null,
             type: "strLit",
             str: interpolatedStringFromString(interpolation),
           };

--- a/ts/nix.ts
+++ b/ts/nix.ts
@@ -1,3 +1,12 @@
+import {
+  InterpolatedString,
+  interpolatedStringFromString,
+  interpolatedStringFromTemplate,
+  mapStrings,
+  renderInterpolatedString,
+} from "./internal/interpolatedString.ts";
+import { checkExhaustiveness, filterNullValues } from "./internal/utils.ts";
+
 /**
  * A union of types that are allowed to be interpolated into the `nixStrLit`
  * template literal function. This is also used in some higher level functions, such as
@@ -20,22 +29,16 @@ export type NixStrLitInterpolatable =
       nixExpression: NixExpression;
     };
 
-type NixAst =
-  | { type: "raw"; raw: InterpolatedString<NixAst> }
-  | { type: "list"; elements: Array<NixAst> }
-  | { type: "attrSet"; elements: Record<string, NixAst> }
-  | { type: "strLit"; str: InterpolatedString<NixAst> };
-
 /**
  * An opaque type representing a Nix expression.
  *
  * It is not advised to construct this type but instead use `nixRaw` or `nixStrLit`.
- *
- * It is not advised to access `__ast` directly except within this file itself.
- * This way all Nix expressions are contained within this opaque type and
- * remain type safe.
  */
-export type NixExpression = { __ast: NixAst };
+export type NixExpression =
+  | { type: "raw"; raw: InterpolatedString<NixExpression> }
+  | { type: "list"; elements: Array<NixExpression> }
+  | { type: "attrSet"; elements: Record<string, NixExpression> }
+  | { type: "strLit"; str: InterpolatedString<NixExpression> };
 
 /**
  * A template literal function to construct `NixExpression`s from raw strings.
@@ -70,17 +73,12 @@ export function nixRaw(
   s: TemplateStringsArray | string,
   ...interpolations: Array<NixExpression>
 ): NixExpression {
-  if (typeof s === "string") {
-    return { __ast: { type: "raw", raw: interpolatedStringFromString(s) } };
-  }
   return {
-    __ast: {
-      type: "raw",
-      raw: interpolatedStringFromTemplate(
-        s,
-        interpolations.map((i) => i.__ast),
-      ),
-    },
+    type: "raw",
+    raw:
+      typeof s === "string"
+        ? interpolatedStringFromString(s)
+        : interpolatedStringFromTemplate(s, interpolations),
   };
 }
 
@@ -99,10 +97,8 @@ export function nixRaw(
  */
 export function nixList(elements: Array<NixExpression>): NixExpression {
   return {
-    __ast: {
-      type: "list",
-      elements: elements.map((e) => e.__ast),
-    },
+    type: "list",
+    elements: elements,
   };
 }
 
@@ -124,15 +120,8 @@ export function nixAttrSet(
   attrSet: Record<string, NixExpression | undefined>,
 ): NixExpression {
   return {
-    __ast: {
-      type: "attrSet",
-      elements: Object.entries(attrSet)
-        .filter((x): x is [string, NixExpression] => x[1] != null)
-        .reduce(
-          (acc, [k, v]) => ({ ...acc, [k]: v.__ast }),
-          {} as Record<string, NixAst>,
-        ),
-    },
+    type: "attrSet",
+    elements: filterNullValues(attrSet),
   };
 }
 
@@ -152,27 +141,25 @@ export function nixStrLit(
   ...interpolations: Array<NixStrLitInterpolatable>
 ): NixExpression {
   if (typeof s === "string") {
-    return { __ast: { type: "strLit", str: interpolatedStringFromString(s) } };
+    return { type: "strLit", str: interpolatedStringFromString(s) };
   }
   return {
-    __ast: {
-      type: "strLit",
-      str: interpolatedStringFromTemplate(
-        s,
-        interpolations.map((interpolation): NixAst => {
-          if (typeof interpolation === "string") {
-            return {
-              type: "strLit",
-              str: interpolatedStringFromString(interpolation),
-            };
-          }
-          if ("__ast" in interpolation) {
-            return interpolation.__ast;
-          }
-          return interpolation.nixExpression.__ast;
-        }),
-      ),
-    },
+    type: "strLit",
+    str: interpolatedStringFromTemplate(
+      s,
+      interpolations.map((interpolation): NixExpression => {
+        if (typeof interpolation === "string") {
+          return {
+            type: "strLit",
+            str: interpolatedStringFromString(interpolation),
+          };
+        }
+        if ("nixExpression" in interpolation) {
+          return interpolation.nixExpression;
+        }
+        return interpolation;
+      }),
+    ),
   };
 }
 
@@ -181,13 +168,10 @@ export function nixStrLit(
  * with incidental dependencies snipped out with "[...]"
  */
 export function toHumanReadable(nixExpr: NixExpression): string {
-  const astToHumanReadable = (node: NixAst): string => {
-    if (node.type !== "strLit") {
-      return "[...]";
-    }
-    return renderInterpolatedString(node.str, astToHumanReadable);
-  };
-  return astToHumanReadable(nixExpr.__ast);
+  if (nixExpr.type !== "strLit") {
+    return "[...]";
+  }
+  return renderInterpolatedString(nixExpr.str, toHumanReadable);
 }
 
 /**
@@ -196,114 +180,40 @@ export function toHumanReadable(nixExpr: NixExpression): string {
  * It is advised to defer calling this unless actually serializing to disk.
  * This way Nix expressions remain as the type `NixExpression`.
  */
-export function toNixString(nixExpr: NixExpression): string {
-  const astToNixString = (node: NixAst): string => {
-    switch (node.type) {
-      case "raw":
-        return renderInterpolatedString(node.raw, astToNixString).trim();
-      case "list":
-        return (
-          "[" + node.elements.map((e) => astToNixString(e)).join(" ") + "]"
+export function renderNixExpression(nixExpr: NixExpression): string {
+  switch (nixExpr.type) {
+    case "raw":
+      return renderInterpolatedString(nixExpr.raw, renderNixExpression).trim();
+    case "list":
+      return "[" + nixExpr.elements.map(renderNixExpression).join(" ") + "]";
+    case "attrSet":
+      return (
+        "{ " +
+        Object.entries(nixExpr.elements)
+          .map(
+            ([k, v]) =>
+              `${renderNixExpression(nixStrLit(k))} = ${renderNixExpression(
+                v,
+              )};`,
+          )
+          .join(" ") +
+        " }"
+      );
+    case "strLit": {
+      const escape = (str: string) =>
+        ["\\", '"', "$"].reduce(
+          (str, char) => str.replaceAll(char, `\\${char}`),
+          str,
         );
-      case "attrSet":
-        return (
-          "{ " +
-          Object.entries(node.elements)
-            .map(
-              ([k, v]) =>
-                `${astToNixString(nixStrLit(k).__ast)} = ${astToNixString(v)};`,
-            )
-            .join(" ") +
-          " }"
-        );
-      case "strLit": {
-        const escape = (str: string) =>
-          ["\\", '"', "$"].reduce(
-            (str, char) => str.replaceAll(char, `\\${char}`),
-            str,
-          );
-        return (
-          '"' +
-          renderInterpolatedString(
-            mapStrings(escape, node.str),
-            (astNode) => "${" + astToNixString(astNode) + "}",
-          ) +
-          '"'
-        );
-      }
+      return (
+        '"' +
+        renderInterpolatedString(
+          mapStrings(escape, nixExpr.str),
+          (astNode) => "${" + renderNixExpression(astNode) + "}",
+        ) +
+        '"'
+      );
     }
-  };
-  return astToNixString(nixExpr.__ast);
-}
-
-/**
- * Represents a string with `T`s interspersed throughout the string.
- *
- * This is a more safe data structure than joining a `TemplateStringsArray`
- * with a `T[]` (which is what tag template functions give you) since it
- * enforces that given N strings, there will always be N-1 interpolations.
- *
- * Example:
- * ```typescript
- * // Given:
- * myTemplateFn`foo${1}bar${2}baz`
- *
- * function myTemplateFn(s: TemplateStringsArray, ...i: Array<number>) {
- *   // s is ["foo", "bar", "baz"]
- *   // i is [1, 2]
- *   // but nothing at the type level enforces that s.length - 1 == i.length
- *
- *   // Using `interpolatedStringFromTemplate` we can convert to a safer `InterpolatedString`:
- *   const interpolatedString = interpolatedStringFromTemplate(s, i);
- *   // interpolatedString is { initial: "foo", rest: [[1, "bar"], [2, "baz"]] }
- * }
- * ```
- */
-type InterpolatedString<T> = {
-  initial: string;
-  rest: Array<[T, string]>;
-};
-
-/**
- * Converts tag template function parameters into `InterpolatedString`s
- */
-function interpolatedStringFromTemplate<T>(
-  s: TemplateStringsArray,
-  interpolations: Array<T>,
-): InterpolatedString<T> {
-  return {
-    initial: s[0],
-    rest: s.slice(1).map((part, i) => [interpolations[i], part]),
-  };
-}
-
-/**
- * Convenience function to create an `InterpolatedString` with only an
- * `initial` (no interpolations).
- */
-function interpolatedStringFromString(s: string): InterpolatedString<never> {
-  return {
-    initial: s,
-    rest: [],
-  };
-}
-
-function renderInterpolatedString<T>(
-  interpolated: InterpolatedString<T>,
-  render: (t: T) => string,
-): string {
-  return interpolated.rest.reduce(
-    (acc, [node, str]) => acc + render(node) + str,
-    interpolated.initial,
-  );
-}
-
-function mapStrings<T>(
-  f: (s: string) => string,
-  interpolated: InterpolatedString<T>,
-): InterpolatedString<T> {
-  return {
-    initial: f(interpolated.initial),
-    rest: interpolated.rest.map(([node, str]) => [node, f(str)]),
-  };
+  }
+  checkExhaustiveness(nixExpr);
 }


### PR DESCRIPTION
Given our talk today about implementing flake input helpers in `nix.ts` I felt like this was a good refactor to do now. By keeping everything in an AST we can start to walk the tree and more accurately understand scopes (and find duplication in the future).