### PR TITLE
Enable github CI for all (including external) PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,8 @@
 name: CI
 
-on: push
+on:
+  - push
+  - pull_request
 
 jobs:
   catchall:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,10 @@
 name: CI
 
 on:
-  - push
-  - pull_request
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   catchall:


### PR DESCRIPTION
Currently, our github CI doesn't run for PRs from forked repos, e.g. for this one:
https://github.com/garnix-io/garn/pull/349

This hopefully fixes that.

I think we still have to manually approve CI runs from external forks. But that seems sensible for now.

Update: I first tried out `on: [push, pull_request]`, but that means that for internal PRs we always get duplicated runs, since they're both a PR *and* a push to a local branch. I changed the config to now:

- Enable CI only for pushes to the `main` branch, *and*
- enable CI for all PRs.

But this means that we won't get CI runs for pushes to branches other then `main` in this repo, if there's no PR open for that branch. So if you want a CI run, you'd *have* to open a PR (possibly a draft PR). I think this is acceptable. WDYT?