### PR TITLE
Clean up output on deno type errors

### DIFF
--- a/garn.cabal
+++ b/garn.cabal
@@ -293,6 +293,7 @@ test-suite spec
     , shake
     , silently
     , string-conversions
+    , strip-ansi-escape
     , template-haskell
     , temporary
     , text

--- a/garn.nix
+++ b/garn.nix
@@ -25,6 +25,7 @@
 , shake
 , silently
 , string-conversions
+, strip-ansi-escape
 , template-haskell
 , temporary
 , text
@@ -101,6 +102,7 @@ mkDerivation {
     shake
     silently
     string-conversions
+    strip-ansi-escape
     template-haskell
     temporary
     text

--- a/package.yaml
+++ b/package.yaml
@@ -93,6 +93,7 @@ tests:
       - pcre-heavy
       - shake
       - silently
+      - strip-ansi-escape
       - wreq
       - yaml
 

--- a/src/Garn/GarnConfig.hs
+++ b/src/Garn/GarnConfig.hs
@@ -126,7 +126,9 @@ readGarnConfig = do
         }
       |]
     hClose mainHandle
-    StdoutUntrimmed (cs -> out) <- run (words "deno run --quiet --check --allow-write --allow-run --allow-read") mainPath
+    (exitCode, StdoutUntrimmed (cs -> out)) <- run (words "deno run --quiet --check --allow-write --allow-run --allow-read") mainPath
+    when (exitCode /= ExitSuccess) $ do
+      exitWith exitCode
     case eitherDecode out :: Either String (Maybe DenoOutput) of
       Left err -> do
         let suggestion = case eitherDecode out :: Either String OnlyTsLibVersion of


### PR DESCRIPTION
This cleans up the error message we get on deno type errors in `garn.ts` files.

Before we would have this line after the type errors:

`garn: command failed with exitcode 1: deno`

I don't think that's useful.

Also, this PR means that when executing the garn tests and running into `deno`
type errors, we would actually see the type errors in the error output of the
test-suite.
