### PR TITLE
Fix generic helper shared namespace bugs

### DIFF
--- a/examples/frontend-create-react-app/flake.nix
+++ b/examples/frontend-create-react-app/flake.nix
@@ -29,9 +29,9 @@
               {
                 buildInputs = dev.buildInputs ++ dev.nativeBuildInputs;
               } "
-      #!\${pkgs.bash}/bin/bash
-      mkdir \$out
-      ${"
+    #!\${pkgs.bash}/bin/bash
+    mkdir \$out
+    ${"
       echo copying source
       cp -r ${(let
     lib = pkgs.lib;
@@ -87,11 +87,11 @@
       }}/node_modules .
       chmod -R u+rwX node_modules
     "}
-      ${"
+    ${"
       npm run build
       cp -rv build/* \$out
     "}
-    ";
+  ";
           "main_node_modules" =
             let
               npmlock2nix = import npmlock2nix-repo {

--- a/examples/haskell/flake.nix
+++ b/examples/haskell/flake.nix
@@ -102,8 +102,8 @@
               {
                 buildInputs = dev.buildInputs ++ dev.nativeBuildInputs;
               } "
-      touch \$out
-      ${"
+    touch \$out
+    ${"
       echo copying source
       cp -r ${(let
     lib = pkgs.lib;
@@ -126,8 +126,8 @@
       chmod -R u+rwX src
       cd src
     "}
-      ${"hlint *.hs"}
-    ";
+    ${"hlint *.hs"}
+  ";
         }
       );
       devShells = forAllSystems (system:

--- a/examples/npm-project/flake.nix
+++ b/examples/npm-project/flake.nix
@@ -73,8 +73,8 @@
               {
                 buildInputs = dev.buildInputs ++ dev.nativeBuildInputs;
               } "
-      touch \$out
-      ${"
+    touch \$out
+    ${"
       echo copying source
       cp -r ${(let
     lib = pkgs.lib;
@@ -130,8 +130,8 @@
       }}/node_modules .
       chmod -R u+rwX node_modules
     "}
-      ${"npm run test"}
-    ";
+    ${"npm run test"}
+  ";
           "project_tsc" =
             let
               dev = (pkgs.mkShell { }).overrideAttrs (finalAttrs: previousAttrs: {
@@ -145,8 +145,8 @@
               {
                 buildInputs = dev.buildInputs ++ dev.nativeBuildInputs;
               } "
-      touch \$out
-      ${"
+    touch \$out
+    ${"
       echo copying source
       cp -r ${(let
     lib = pkgs.lib;
@@ -202,8 +202,8 @@
       }}/node_modules .
       chmod -R u+rwX node_modules
     "}
-      ${"npm run tsc"}
-    ";
+    ${"npm run tsc"}
+  ";
         }
       );
       devShells = forAllSystems (system:

--- a/test/spec/CheckSpec.hs
+++ b/test/spec/CheckSpec.hs
@@ -92,6 +92,23 @@ spec = do
           stderr output `shouldContain` "DEF"
           exitCode output `shouldBe` ExitFailure 1
 
+        it "supports running checks on projects containing a dep 'check'" $ \onTestFailureLog -> do
+          writeFile
+            "garn.ts"
+            [i|
+              import * as garn from "#{repoDir}/ts/mod.ts"
+              export const project = garn.mkProject({
+                description: "",
+                defaultEnvironment: garn.mkEnvironment(),
+              }, {})
+                .addExecutable("check", "true")
+                .addCheck("test", "echo this works " + Date.now());
+            |]
+          output <- runGarn ["check", "project"] "" repoDir Nothing
+          onTestFailureLog output
+          stderr output `shouldContain` "this works"
+          exitCode output `shouldBe` ExitSuccess
+
         it "does not error if there are spaces in the check key name" $ \onTestFailureLog -> do
           writeHaskellProject repoDir
           writeFile

--- a/test/spec/RunSpec.hs
+++ b/test/spec/RunSpec.hs
@@ -90,6 +90,23 @@ spec =
           stdout output `shouldBe` "Hello, world!\n"
           exitCode output `shouldBe` ExitSuccess
 
+        it "supports running executables on projects containing a dep 'shell'" $ \onTestFailureLog -> do
+          writeFile
+            "garn.ts"
+            [i|
+              import * as garn from "#{repoDir}/ts/mod.ts"
+              export const project = garn.mkProject({
+                description: "",
+                defaultEnvironment: garn.mkEnvironment(),
+              }, {})
+                .addExecutable("shell", "true")
+                .addExecutable("greet", "echo hello world");
+            |]
+          output <- runGarn ["run", "project.greet"] "" repoDir Nothing
+          onTestFailureLog output
+          stdout output `shouldContain` "hello world"
+          exitCode output `shouldBe` ExitSuccess
+
         it "allows specifying deeply nested executables" $ \onTestFailureLog -> do
           writeFile
             "garn.ts"

--- a/ts/environment.ts
+++ b/ts/environment.ts
@@ -1,5 +1,5 @@
-import { Check } from "./check.ts";
-import { Executable } from "./executable.ts";
+import { Check, mkCheck } from "./check.ts";
+import { Executable, mkShellExecutable } from "./executable.ts";
 import { hasTag, nixSource } from "./internal/utils.ts";
 import {
   NixStrLitInterpolatable,
@@ -7,9 +7,8 @@ import {
   nixList,
   nixRaw,
   nixStrLit,
-  toHumanReadable,
 } from "./nix.ts";
-import { Package, mkPackage } from "./package.ts";
+import { Package, mkShellPackage } from "./package.ts";
 
 /**
  * `Environment`s define what files and tools are available to `Executables`,
@@ -24,6 +23,8 @@ import { Package, mkPackage } from "./package.ts";
 export type Environment = {
   tag: "environment";
   nixExpression: NixExpression;
+  setup: NixExpression;
+
   /**
    * Creates a new environment based on this one that includes the specified nix packages.
    */
@@ -65,9 +66,7 @@ export function shell(
   s: TemplateStringsArray | string,
   ...args: Array<NixStrLitInterpolatable>
 ) {
-  return typeof s === "string"
-    ? emptyEnvironment.shell(s)
-    : emptyEnvironment.shell(s, ...args);
+  return mkShellExecutable(emptyEnvironment, s, ...args);
 }
 
 /**
@@ -88,9 +87,7 @@ export function check(
   s: TemplateStringsArray | string,
   ...args: Array<NixStrLitInterpolatable>
 ) {
-  return typeof s === "string"
-    ? emptyEnvironment.check(s)
-    : emptyEnvironment.check(s, ...args);
+  return mkCheck(emptyEnvironment, s, ...args);
 }
 
 /**
@@ -113,7 +110,7 @@ export function build(
   s: TemplateStringsArray,
   ...args: Array<NixStrLitInterpolatable>
 ) {
-  return emptyEnvironment.build(s, ...args);
+  return mkShellPackage(emptyEnvironment, s, ...args);
 }
 
 /**
@@ -147,73 +144,23 @@ export function mkEnvironment(
   return {
     tag: "environment",
     nixExpression,
+    setup: setup || nixStrLit``,
     check(
       this: Environment,
       s: TemplateStringsArray | string,
       ...args: Array<NixStrLitInterpolatable>
     ): Check {
-      const checkScript =
-        typeof s === "string" ? nixStrLit(s) : nixStrLit(s, ...args);
-      const wrappedScript = nixStrLit`
-      touch $out
-      ${setup || ""}
-      ${checkScript}
-    `;
-      return {
-        tag: "check",
-        nixExpression: nixRaw`
-        let
-            dev = ${this.nixExpression};
-        in
-        pkgs.runCommand "check" {
-          buildInputs = dev.buildInputs ++ dev.nativeBuildInputs;
-        } ${wrappedScript}
-      `,
-      };
+      return mkCheck(this, s, ...args);
     },
     shell(
       this: Environment,
       s: TemplateStringsArray | string,
       ...args: Array<NixStrLitInterpolatable>
     ) {
-      const cmdToExecute =
-        typeof s === "string" ? nixStrLit(s) : nixStrLit(s, ...args);
-      const shellEnv = nixRaw`
-      let
-        dev = ${this.nixExpression};
-        shell = ${cmdToExecute};
-        buildPath = pkgs.runCommand "build-inputs-path" {
-          inherit (dev) buildInputs nativeBuildInputs;
-        } "echo $PATH > $out";
-      in
-      pkgs.writeScript "shell-env"  ''
-        #!\${pkgs.bash}/bin/bash
-        export PATH=$(cat \${buildPath}):$PATH
-        \${dev.shellHook}
-        \${shell} "$@"
-      ''
-    `;
-      return {
-        tag: "executable",
-        description: `Executes ${toHumanReadable(cmdToExecute)}`,
-        nixExpression: nixStrLit`${shellEnv}`,
-      };
+      return mkShellExecutable(this, s, ...args);
     },
     build(this, s, ...args) {
-      const cmdToExecute = nixStrLit(s, ...args);
-      const wrappedScript = nixStrLit`
-      #!\${pkgs.bash}/bin/bash
-      mkdir $out
-      ${setup || ""}
-      ${cmdToExecute}
-    `;
-      const pkg = nixRaw`
-      let dev = ${this.nixExpression}; in
-      pkgs.runCommand "garn-pkg" {
-        buildInputs = dev.buildInputs ++ dev.nativeBuildInputs;
-      } ${wrappedScript}
-    `;
-      return mkPackage(pkg);
+      return mkShellPackage(this, s, ...args);
     },
     withDevTools(this, extraDevTools) {
       return {

--- a/ts/package.ts
+++ b/ts/package.ts
@@ -1,5 +1,11 @@
+import { Environment } from "./environment.ts";
 import { hasTag } from "./internal/utils.ts";
-import { NixExpression } from "./nix.ts";
+import {
+  NixExpression,
+  NixStrLitInterpolatable,
+  nixRaw,
+  nixStrLit,
+} from "./nix.ts";
 
 /**
  * `Package`s are instructions to `garn` about how to _build_ a set of files.
@@ -34,4 +40,26 @@ export function mkPackage(
     nixExpression,
     description,
   };
+}
+
+export function mkShellPackage(
+  env: Environment,
+  s: TemplateStringsArray | string,
+  ...args: Array<NixStrLitInterpolatable>
+) {
+  const cmdToExecute =
+    typeof s === "string" ? nixStrLit(s) : nixStrLit(s, ...args);
+  const wrappedScript = nixStrLit`
+    #!\${pkgs.bash}/bin/bash
+    mkdir $out
+    ${env.setup}
+    ${cmdToExecute}
+  `;
+  const pkg = nixRaw`
+    let dev = ${env.nixExpression}; in
+    pkgs.runCommand "garn-pkg" {
+      buildInputs = dev.buildInputs ++ dev.nativeBuildInputs;
+    } ${wrappedScript}
+  `;
+  return mkPackage(pkg);
 }

--- a/ts/project.test.ts
+++ b/ts/project.test.ts
@@ -2,51 +2,51 @@ import { Check } from "./check.ts";
 import { Executable } from "./executable.ts";
 import { Project } from "./project.ts";
 
-const assertIsCheck = (_c: Check) => {};
-const assertIsExecutable = (_e: Executable) => {};
+const assertTypeIsCheck = (_c: Check) => {};
+const assertTypeIsExecutable = (_e: Executable) => {};
 
-const _testAddCheck = (project: Project) => {
+const _testTypeCheckingOfAddCheck = (project: Project) => {
   const p = project
     .addExecutable("unrelated1", "true")
     .addCheck("check", "true")
     .addExecutable("unrelated2", "true");
-  assertIsCheck(p.check);
-  assertIsExecutable(p.unrelated1);
-  assertIsExecutable(p.unrelated2);
+  assertTypeIsCheck(p.check);
+  assertTypeIsExecutable(p.unrelated1);
+  assertTypeIsExecutable(p.unrelated2);
   // @ts-expect-error - check should be the actual check now, not the helper
   p.check``;
 };
 
-const _testAddCheckTemplate = (project: Project) => {
+const _testTypeCheckingOfAddCheckTemplate = (project: Project) => {
   const p = project
     .addExecutable("unrelated1", "true")
     .addCheck("check")`true`.addExecutable("unrelated2", "true");
-  assertIsCheck(p.check);
-  assertIsExecutable(p.unrelated1);
-  assertIsExecutable(p.unrelated2);
+  assertTypeIsCheck(p.check);
+  assertTypeIsExecutable(p.unrelated1);
+  assertTypeIsExecutable(p.unrelated2);
   // @ts-expect-error - check should be the actual check now, not the helper
   p.check``;
 };
 
-const _testAddExecutable = (project: Project) => {
+const _testTypeCheckingOfAddExecutable = (project: Project) => {
   const p = project
     .addExecutable("unrelated1", "true")
     .addExecutable("shell", "true")
     .addExecutable("unrelated2", "true");
-  assertIsExecutable(p.shell);
-  assertIsExecutable(p.unrelated1);
-  assertIsExecutable(p.unrelated2);
+  assertTypeIsExecutable(p.shell);
+  assertTypeIsExecutable(p.unrelated1);
+  assertTypeIsExecutable(p.unrelated2);
   // @ts-expect-error - shell should be the actual executable now, not the helper
   p.shell``;
 };
 
-const _testAddExecutableTemplate = (project: Project) => {
+const _testTypeCheckingOfAddExecutableTemplate = (project: Project) => {
   const p = project
     .addExecutable("unrelated1", "true")
     .addExecutable("shell")`true`.addExecutable("unrelated2", "true");
-  assertIsExecutable(p.shell);
-  assertIsExecutable(p.unrelated1);
-  assertIsExecutable(p.unrelated2);
+  assertTypeIsExecutable(p.shell);
+  assertTypeIsExecutable(p.unrelated1);
+  assertTypeIsExecutable(p.unrelated2);
   // @ts-expect-error - shell should be the actual executable now, not the helper
   p.shell``;
 };

--- a/ts/project.test.ts
+++ b/ts/project.test.ts
@@ -1,0 +1,52 @@
+import { Check } from "./check.ts";
+import { Executable } from "./executable.ts";
+import { Project } from "./project.ts";
+
+const assertIsCheck = (_c: Check) => {};
+const assertIsExecutable = (_e: Executable) => {};
+
+const _testAddCheck = (project: Project) => {
+  const p = project
+    .addExecutable("unrelated1", "true")
+    .addCheck("check", "true")
+    .addExecutable("unrelated2", "true");
+  assertIsCheck(p.check);
+  assertIsExecutable(p.unrelated1);
+  assertIsExecutable(p.unrelated2);
+  // @ts-expect-error - check should be the actual check now, not the helper
+  p.check``;
+};
+
+const _testAddCheckTemplate = (project: Project) => {
+  const p = project
+    .addExecutable("unrelated1", "true")
+    .addCheck("check")`true`.addExecutable("unrelated2", "true");
+  assertIsCheck(p.check);
+  assertIsExecutable(p.unrelated1);
+  assertIsExecutable(p.unrelated2);
+  // @ts-expect-error - check should be the actual check now, not the helper
+  p.check``;
+};
+
+const _testAddExecutable = (project: Project) => {
+  const p = project
+    .addExecutable("unrelated1", "true")
+    .addExecutable("shell", "true")
+    .addExecutable("unrelated2", "true");
+  assertIsExecutable(p.shell);
+  assertIsExecutable(p.unrelated1);
+  assertIsExecutable(p.unrelated2);
+  // @ts-expect-error - shell should be the actual executable now, not the helper
+  p.shell``;
+};
+
+const _testAddExecutableTemplate = (project: Project) => {
+  const p = project
+    .addExecutable("unrelated1", "true")
+    .addExecutable("shell")`true`.addExecutable("unrelated2", "true");
+  assertIsExecutable(p.shell);
+  assertIsExecutable(p.unrelated1);
+  assertIsExecutable(p.unrelated2);
+  // @ts-expect-error - shell should be the actual executable now, not the helper
+  p.shell``;
+};

--- a/ts/project.ts
+++ b/ts/project.ts
@@ -72,14 +72,14 @@ type ProjectHelpers = {
     this: T,
     name: Name,
     executable: string,
-  ): T & { [n in Name]: Executable };
+  ): Omit<T, Name> & { [n in Name]: Executable };
   addExecutable<T extends Project, Name extends string>(
     this: T,
     name: Name,
   ): (
     _s: TemplateStringsArray,
     ..._args: Array<NixStrLitInterpolatable>
-  ) => T & { [n in Name]: Executable };
+  ) => Omit<T, Name> & { [n in Name]: Executable };
 
   /**
    * Adds a Check with the given name to the Project that runs in a *pure*
@@ -94,14 +94,14 @@ type ProjectHelpers = {
     this: T,
     name: Name,
     check: string,
-  ): T & { [n in Name]: Check };
+  ): Omit<T, Name> & { [n in Name]: Check };
   addCheck<T extends Project, Name extends string>(
     this: T,
     name: Name,
   ): (
     _s: TemplateStringsArray,
     ..._args: Array<NixStrLitInterpolatable>
-  ) => T & { [n in Name]: Check };
+  ) => Omit<T, Name> & { [n in Name]: Check };
 };
 
 export function isProject(p: unknown): p is Project {

--- a/website/flake.nix
+++ b/website/flake.nix
@@ -78,8 +78,8 @@
               {
                 buildInputs = dev.buildInputs ++ dev.nativeBuildInputs;
               } "
-      touch \$out
-      ${"
+    touch \$out
+    ${"
       echo copying source
       cp -r ${(let
     lib = pkgs.lib;
@@ -135,8 +135,8 @@
       }}/node_modules .
       chmod -R u+rwX node_modules
     "}
-      ${"npm run tsc"}
-    ";
+    ${"npm run tsc"}
+  ";
           "website_fmt-check" =
             let
               dev = ((pkgs.mkShell { }).overrideAttrs (finalAttrs: previousAttrs: {
@@ -155,8 +155,8 @@
               {
                 buildInputs = dev.buildInputs ++ dev.nativeBuildInputs;
               } "
-      touch \$out
-      ${"
+    touch \$out
+    ${"
       echo copying source
       cp -r ${(let
     lib = pkgs.lib;
@@ -212,8 +212,8 @@
       }}/node_modules .
       chmod -R u+rwX node_modules
     "}
-      ${"prettier src/**/*.tsx src/**/*.ts --check"}
-    ";
+    ${"prettier src/**/*.tsx src/**/*.ts --check"}
+  ";
         }
       );
       devShells = forAllSystems (system:
@@ -305,13 +305,13 @@
 
     # copy the vscodium config
     cp -r ${let dev = pkgs.mkShell {}; in
-      pkgs.runCommand "garn-pkg" {
-        buildInputs = dev.buildInputs ++ dev.nativeBuildInputs;
-      } "
-      #!\${pkgs.bash}/bin/bash
-      mkdir \$out
-      ${""}
-      ${"
+    pkgs.runCommand "garn-pkg" {
+      buildInputs = dev.buildInputs ++ dev.nativeBuildInputs;
+    } "
+    #!\${pkgs.bash}/bin/bash
+    mkdir \$out
+    ${""}
+    ${"
     USER_CONFIG=.config/VSCodium/User
     if test \$(uname) = \"Darwin\" ; then
       USER_CONFIG=\"Library/Application Support/VSCodium/User\"
@@ -333,13 +333,13 @@
   }} \"\$out/\$USER_CONFIG/settings.json\"
     mkdir -p \"\$out/\$USER_CONFIG/globalStorage\"
     cp ${let dev = pkgs.mkShell {}; in
-      pkgs.runCommand "garn-pkg" {
-        buildInputs = dev.buildInputs ++ dev.nativeBuildInputs;
-      } "
-      #!\${pkgs.bash}/bin/bash
-      mkdir \$out
-      ${""}
-      ${"
+    pkgs.runCommand "garn-pkg" {
+      buildInputs = dev.buildInputs ++ dev.nativeBuildInputs;
+    } "
+    #!\${pkgs.bash}/bin/bash
+    mkdir \$out
+    ${""}
+    ${"
     set -euo pipefail
     cat ${pkgs.writeTextFile {
     name = "${"sqlite-script"}";
@@ -350,9 +350,9 @@ INSERT INTO ItemTable VALUES('denoland.vscode-deno','{\"deno.welcomeShown\":true
 COMMIT;"}";
   }} | ${pkgs.sqlite}/bin/sqlite3 \$out/state.vscdb
   "}
-    "}/state.vscdb \"\$out/\$USER_CONFIG/globalStorage/state.vscdb\"
+  "}/state.vscdb \"\$out/\$USER_CONFIG/globalStorage/state.vscdb\"
   "}
-    "}/. \$TEMP_DIR
+  "}/. \$TEMP_DIR
     chmod -R u+rwX \$TEMP_DIR
 
     # copy the deno cache


### PR DESCRIPTION
This fixes the runtime errors when there is an executable/check/package on a project named `shell`, `check`, or `build`. We were using these helpers internally on `T` assuming that they were available, but since we share scope with user-defined executables/checks/packages we shouldn't assume this.

I think in a future PR it would be nice to also move `ProjectData` in an object nested under a `Symbol()` so that a project dep named `"description"` for example doesn't break things, but for now that seems a lot less likely to happen.