### PR TITLE
Move GOMOD2NIX_REPO into ts/go/mod.ts

### DIFF
--- a/ts/go/consts.ts
+++ b/ts/go/consts.ts
@@ -1,2 +1,0 @@
-export const GOMOD2NIX_REPO =
-  "github:nix-community/gomod2nix?rev=f95720e89af6165c8c0aa77f180461fe786f3c21";

--- a/ts/go/mod.ts
+++ b/ts/go/mod.ts
@@ -5,7 +5,9 @@ import { mkProject, Project } from "../project.ts";
 import * as path from "https://deno.land/std@0.202.0/path/mod.ts";
 import { getDotGarnProjectDir } from "../internal/garn_dir.ts";
 import { nixSource } from "../internal/utils.ts";
-import { GOMOD2NIX_REPO } from "./consts.ts";
+
+const GOMOD2NIX_REPO =
+  "github:nix-community/gomod2nix?rev=f95720e89af6165c8c0aa77f180461fe786f3c21";
 
 const getGoModNixToml = (src: string): NixExpression => {
   const gen = new Deno.Command("nix", {

--- a/ts/internal/runner.ts
+++ b/ts/internal/runner.ts
@@ -2,7 +2,6 @@ import { isProject, Project } from "../project.ts";
 import { isPackage, Package } from "../package.ts";
 import { Check, isCheck } from "../check.ts";
 import { checkExhaustiveness, mapKeys, mapValues } from "./utils.ts";
-import { GOMOD2NIX_REPO } from "../go/consts.ts";
 import {
   nixFlakeDep,
   nixAttrSet,


### PR DESCRIPTION
This used to be in a separate file to allow `runner` to include it in the flake dependencies, however since 953b2c4 (#360) we no longer need to import this in runner and this import was unused.