### PR TITLE
Improve --help descriptions for vite and gh-pages

### DIFF
--- a/examples/vite-frontend/flake.nix
+++ b/examples/vite-frontend/flake.nix
@@ -239,7 +239,8 @@
     });
           nodejs = pkgs.nodejs-18_x;
         }}/bin:\$PATH
-      vite";
+      vite
+    ";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";
@@ -292,7 +293,8 @@
     });
           nodejs = pkgs.nodejs-18_x;
         }}/bin:\$PATH
-      vite preview";
+      vite preview
+    ";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";

--- a/ts/deployToGhPages.ts
+++ b/ts/deployToGhPages.ts
@@ -68,7 +68,9 @@ export function deployToGhPages<T>(
         git fetch --quiet "$TMP_DST" gh-pages:gh-pages
         >&2 echo -e 'Created commit to "gh-pages" branch, but it has not been pushed yet'
         >&2 echo -e 'Run ${ansiBold}git push <remote> gh-pages:gh-pages${ansiReset} to deploy'
-      `,
+      `.setDescription(
+        "Builds this project and commits the output to your local `gh-pages` branch",
+      ),
     };
   };
 }

--- a/ts/executable.ts
+++ b/ts/executable.ts
@@ -32,6 +32,11 @@ export type Executable = {
    * The executable description is rendered in the executable list when running `garn run`.
    */
   description: string;
+
+  /**
+   * Update the description for this `Executable`
+   */
+  setDescription: (this: Executable, newDescription: string) => Executable;
 };
 
 export function isExecutable(e: unknown): e is Executable {
@@ -51,6 +56,13 @@ export function mkExecutable(
     tag: "executable",
     nixExpression,
     description,
+
+    setDescription(this: Executable, newDescription: string): Executable {
+      return {
+        ...this,
+        description: newDescription,
+      };
+    },
   };
 }
 

--- a/ts/javascript/vite.ts
+++ b/ts/javascript/vite.ts
@@ -52,12 +52,14 @@ export const plugin: Plugin<
         exit 1
       fi
       vite build --outDir $out
-    `,
+    `.setDescription("Builds this vite package for production"),
     dev: base.defaultEnvironment.shell`
       export PATH=${base.node_modules}/bin:$PATH
-      vite`,
+      vite
+    `.setDescription("Starts vite dev server"),
     preview: base.defaultEnvironment.shell`
       export PATH=${base.node_modules}/bin:$PATH
-      vite preview`,
+      vite preview
+    `.setDescription("Locally previews a production build"),
   };
 };

--- a/ts/package.ts
+++ b/ts/package.ts
@@ -21,6 +21,11 @@ export type Package = {
   tag: "package";
   nixExpression: NixExpression;
   description: string;
+
+  /**
+   * Update the description for this `Package`
+   */
+  setDescription: (this: Package, newDescription: string) => Package;
 };
 
 export function isPackage(x: unknown): x is Package {
@@ -38,6 +43,13 @@ export function mkPackage(
     tag: "package",
     nixExpression,
     description,
+
+    setDescription(this: Package, newDescription: string): Package {
+      return {
+        ...this,
+        description: newDescription,
+      };
+    },
   };
 }
 


### PR DESCRIPTION
The descriptions of these plugins was a bit sad, being something like `Executes "set -e ..."`. This makes the help text for projects using the Vite or GitHub pages plugins much nicer.