### PR TITLE
Replace executable mechanism in mkHaskellProject

### DIFF
--- a/examples/haskell/flake.nix
+++ b/examples/haskell/flake.nix
@@ -34,13 +34,10 @@
                       fileName = lastSafe (lib.strings.splitString "/" path);
                     in
                     fileName != "flake.nix" &&
-                      fileName != "garn.ts";
+                    fileName != "garn.ts";
                 }
             )
-            { })
-          // {
-            meta.mainProgram = "helloFromHaskell";
-          };
+            { });
         }
       );
       checks = forAllSystems (system:
@@ -74,13 +71,10 @@
                               fileName = lastSafe (lib.strings.splitString "/" path);
                             in
                             fileName != "flake.nix" &&
-                              fileName != "garn.ts";
+                            fileName != "garn.ts";
                         }
                     )
-                    { })
-                  // {
-                    meta.mainProgram = "helloFromHaskell";
-                  };
+                    { });
                 in
                 (if expr ? env
                 then expr.env
@@ -159,13 +153,10 @@
                           fileName = lastSafe (lib.strings.splitString "/" path);
                         in
                         fileName != "flake.nix" &&
-                          fileName != "garn.ts";
+                        fileName != "garn.ts";
                     }
                 )
-                { })
-              // {
-                meta.mainProgram = "helloFromHaskell";
-              };
+                { });
             in
             (if expr ? env
             then expr.env
@@ -192,10 +183,35 @@
           };
         in
         {
-          "helloFromHaskell" = {
+          "helloFromHaskell/hello" = {
             "type" = "app";
             "program" = "${let
-        dev = pkgs.mkShell {};
+        dev = let expr = (pkgs.haskell.packages.ghc94.callCabal2nix
+        "garn-pkg"
+        (let
+    lib = pkgs.lib;
+    lastSafe = list :
+      if lib.lists.length list == 0
+        then null
+        else lib.lists.last list;
+  in
+  builtins.path
+    {
+      path = ./.;
+      name = "source";
+      filter = path: type:
+        let
+          fileName = lastSafe (lib.strings.splitString "/" path);
+        in
+         fileName != "flake.nix" &&
+         fileName != "garn.ts";
+    })
+        { });
+    in
+      (if expr ? env
+        then expr.env
+        else pkgs.mkShell { inputsFrom = [ expr ]; }
+      );
         shell = "${(pkgs.haskell.packages.ghc94.callCabal2nix
         "garn-pkg"
         (let
@@ -216,10 +232,7 @@
          fileName != "flake.nix" &&
          fileName != "garn.ts";
     })
-        { })
-        // {
-          meta.mainProgram = "helloFromHaskell";
-        }}/bin/${"helloFromHaskell"}";
+        { })}/bin/${"hello"}";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";

--- a/examples/haskell/garn.ts
+++ b/examples/haskell/garn.ts
@@ -5,8 +5,8 @@ export const helloFromHaskell = garn.haskell
   .mkHaskellProject({
     description: "My haskell executable",
     compiler: "ghc94",
+    executables: ["hello"],
     src: ".",
   })
   .withDevTools([nixpkgs.hlint])
-  .addCheck("hlint", "hlint *.hs")
-  .withCabalExecutable("helloFromHaskell");
+  .addCheck("hlint", "hlint *.hs");

--- a/examples/haskell/garn.ts
+++ b/examples/haskell/garn.ts
@@ -4,9 +4,9 @@ import * as nixpkgs from "http://localhost:8777/nixpkgs.ts";
 export const helloFromHaskell = garn.haskell
   .mkHaskellProject({
     description: "My haskell executable",
-    executable: "helloFromHaskell",
     compiler: "ghc94",
     src: ".",
   })
   .withDevTools([nixpkgs.hlint])
-  .addCheck("hlint", "hlint *.hs");
+  .addCheck("hlint", "hlint *.hs")
+  .withCabalExecutable("helloFromHaskell");

--- a/examples/haskell/helloFromHaskell.cabal
+++ b/examples/haskell/helloFromHaskell.cabal
@@ -8,7 +8,7 @@ name:           helloFromHaskell
 version:        0.0.0
 build-type:     Simple
 
-executable helloFromHaskell
+executable hello
   main-is: Main.hs
   other-modules:
       Paths_helloFromHaskell

--- a/examples/haskell/package.yaml
+++ b/examples/haskell/package.yaml
@@ -1,7 +1,7 @@
 name: helloFromHaskell
 
 executables:
-  helloFromHaskell:
+  hello:
     main: Main.hs
     dependencies:
       - base

--- a/examples/monorepo/flake.nix
+++ b/examples/monorepo/flake.nix
@@ -73,13 +73,10 @@
                       fileName = lastSafe (lib.strings.splitString "/" path);
                     in
                     fileName != "flake.nix" &&
-                      fileName != "garn.ts";
+                    fileName != "garn.ts";
                 }
             )
-            { })
-          // {
-            meta.mainProgram = "helloFromHaskell";
-          };
+            { });
           "npmFrontend/node_modules" =
             let
               npmlock2nix = import npmlock2nix-repo {
@@ -204,13 +201,10 @@
                           fileName = lastSafe (lib.strings.splitString "/" path);
                         in
                         fileName != "flake.nix" &&
-                          fileName != "garn.ts";
+                        fileName != "garn.ts";
                     }
                 )
-                { })
-              // {
-                meta.mainProgram = "helloFromHaskell";
-              };
+                { });
             in
             (if expr ? env
             then expr.env
@@ -297,10 +291,35 @@
         ${shell} "$@"
       ''}";
           };
-          "haskell" = {
+          "haskell/hello" = {
             "type" = "app";
             "program" = "${let
-        dev = pkgs.mkShell {};
+        dev = let expr = (pkgs.haskell.packages.ghc94.callCabal2nix
+        "garn-pkg"
+        (let
+    lib = pkgs.lib;
+    lastSafe = list :
+      if lib.lists.length list == 0
+        then null
+        else lib.lists.last list;
+  in
+  builtins.path
+    {
+      path = ./haskell;
+      name = "source";
+      filter = path: type:
+        let
+          fileName = lastSafe (lib.strings.splitString "/" path);
+        in
+         fileName != "flake.nix" &&
+         fileName != "garn.ts";
+    })
+        { });
+    in
+      (if expr ? env
+        then expr.env
+        else pkgs.mkShell { inputsFrom = [ expr ]; }
+      );
         shell = "${(pkgs.haskell.packages.ghc94.callCabal2nix
         "garn-pkg"
         (let
@@ -321,10 +340,7 @@
          fileName != "flake.nix" &&
          fileName != "garn.ts";
     })
-        { })
-        // {
-          meta.mainProgram = "helloFromHaskell";
-        }}/bin/${"helloFromHaskell"}";
+        { })}/bin/${"hello"}";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";
@@ -417,7 +433,32 @@
         ${dev.shellHook}
         ${shell} "$@"
       ''}"; "environment" = []; }; "haskell" = { "command" = "${let
-        dev = pkgs.mkShell {};
+        dev = let expr = (pkgs.haskell.packages.ghc94.callCabal2nix
+        "garn-pkg"
+        (let
+    lib = pkgs.lib;
+    lastSafe = list :
+      if lib.lists.length list == 0
+        then null
+        else lib.lists.last list;
+  in
+  builtins.path
+    {
+      path = ./haskell;
+      name = "source";
+      filter = path: type:
+        let
+          fileName = lastSafe (lib.strings.splitString "/" path);
+        in
+         fileName != "flake.nix" &&
+         fileName != "garn.ts";
+    })
+        { });
+    in
+      (if expr ? env
+        then expr.env
+        else pkgs.mkShell { inputsFrom = [ expr ]; }
+      );
         shell = "${(pkgs.haskell.packages.ghc94.callCabal2nix
         "garn-pkg"
         (let
@@ -438,10 +479,7 @@
          fileName != "flake.nix" &&
          fileName != "garn.ts";
     })
-        { })
-        // {
-          meta.mainProgram = "helloFromHaskell";
-        }}/bin/${"helloFromHaskell"}";
+        { })}/bin/${"hello"}";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";

--- a/examples/monorepo/garn.ts
+++ b/examples/monorepo/garn.ts
@@ -24,6 +24,6 @@ export const npmFrontend = garn.javascript
 
 export const startAll = garn.processCompose({
   backend: backend.run,
-  haskell: haskell.defaultExecutable!,
+  haskell: haskell.hello,
   frontend: npmFrontend.run,
 });

--- a/examples/monorepo/garn.ts
+++ b/examples/monorepo/garn.ts
@@ -9,7 +9,7 @@ export const backend = garn.go
 
 export const haskell = garn.haskell.mkHaskellProject({
   description: "My haskell executable",
-  executable: "helloFromHaskell",
+  executables: ["hello"],
   compiler: "ghc94",
   src: "haskell",
 });

--- a/garn.ts
+++ b/garn.ts
@@ -1,0 +1,9 @@
+import * as garn from "https://garn.io/ts/v0.0.15/mod.ts";
+import * as pkgs from "https://garn.io/ts/v0.0.15/nixpkgs.ts";
+
+export const garn = garn.haskell.mkHaskellProject({
+  description: "",
+  compiler: "ghc94",
+  executables: ["garn","codegen"],
+  src: "."
+})

--- a/justfile
+++ b/justfile
@@ -135,7 +135,7 @@ run-garn example *args="": hpack
 
 check-examples:
   just run-garn haskell check
-  just run-garn haskell run helloFromHaskell
+  just run-garn haskell run helloFromHaskell.hello
   just run-garn frontend-create-react-app check
   rm examples/frontend-create-react-app/result
   just run-garn frontend-create-react-app build main

--- a/scripts/cabal2json.hs
+++ b/scripts/cabal2json.hs
@@ -5,12 +5,15 @@ import qualified Data.Aeson as A
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.Map as M
+import Distribution.PackageDescription.Configuration
 import Distribution.PackageDescription.Parsec
 import Distribution.Parsec
+import Distribution.Types.Executable
 import Distribution.Types.GenericPackageDescription
 import Distribution.Types.PackageDescription
 import Distribution.Types.PackageId
 import Distribution.Types.PackageName
+import Distribution.Types.UnqualComponentName
 import Distribution.Utils.ShortText
 import System.Environment
 
@@ -21,7 +24,7 @@ main = do
       [x] -> pure x
       _ -> fail "usage: cabal2json <cabal-file>"
   Just r <- parseGenericPackageDescriptionMaybe <$> BS.readFile cabalFile
-  BSL.putStr $ A.encode $ toJSON (packageDescription r)
+  BSL.putStr $ A.encode $ toJSON (flattenPackageDescription r)
   putStrLn ""
 
 toJSON :: PackageDescription -> A.Value
@@ -29,5 +32,6 @@ toJSON p =
   A.object
     [ "name" A..= (unPackageName $ pkgName (package p)),
       "description" A..= (fromShortText $ description p),
-      "synopsis" A..= (fromShortText $ synopsis p)
+      "synopsis" A..= (fromShortText $ synopsis p),
+      "executables" A..= (unUnqualComponentName . exeName <$> executables p)
     ]

--- a/test/check-isolated-garn.sh
+++ b/test/check-isolated-garn.sh
@@ -30,7 +30,7 @@ done
 
 cd examples/haskell
 expected="Hello, world!"
-res="$(run-in-isolation garn run helloFromHaskell)"
+res="$(run-in-isolation garn run helloFromHaskell.hello)"
 if [[ $res == $expected ]]; then
   echo "Smoke test successful"
 else

--- a/test/spec/CheckSpec.hs
+++ b/test/spec/CheckSpec.hs
@@ -39,7 +39,7 @@ spec = do
 
               export const haskell = garn.haskell.mkHaskellProject({
                 description: "mkHaskellProject-test",
-                executable: "garn-test",
+                executables: ["garn-test"],
                 compiler: "ghc94",
                 src: "."
               })
@@ -59,7 +59,7 @@ spec = do
 
               export const haskell = garn.haskell.mkHaskellProject({
                 description: "mkHaskellProject-test",
-                executable: "garn-test",
+                executables: ["garn-test"],
                 compiler: "ghc94",
                 src: "."
               })
@@ -168,7 +168,7 @@ spec = do
 
                   export const haskell = garn.haskell.mkHaskellProject({
                     description: "mkHaskellProject-test",
-                    executable: "garn-test",
+                    executables: ["garn-test"],
                     compiler: "ghc94",
                     src: "."
                   })

--- a/test/spec/EnterSpec.hs
+++ b/test/spec/EnterSpec.hs
@@ -37,7 +37,7 @@ spec = do
 
                   export const foo = mkHaskellProject({
                     description: "mkHaskellProject-test",
-                    executable: "garn-test",
+                    executables: ["garn-test"],
                     compiler: "ghc94",
                     src: "."
                   })
@@ -58,7 +58,7 @@ spec = do
 
                   export const foo = mkHaskellProject({
                     description: "mkHaskellProject-test",
-                    executable: "garn-test",
+                    executables: ["garn-test"],
                     compiler: "ghc94",
                     src: "."
                   })
@@ -84,7 +84,7 @@ spec = do
 
                   export const foo = mkHaskellProject({
                     description: "mkHaskellProject-test",
-                    executable: "garn-test",
+                    executables: ["garn-test"],
                     compiler: "ghc94",
                     src: "."
                   })
@@ -106,7 +106,7 @@ spec = do
 
                   export const foo = mkHaskellProject({
                     description: "mkHaskellProject-test",
-                    executable: "garn-test",
+                    executables: ["garn-test"],
                     compiler: "ghc94",
                     src: "."
                   })

--- a/test/spec/GarnSpec.hs
+++ b/test/spec/GarnSpec.hs
@@ -93,7 +93,7 @@ spec = do
       it "generates formatted flakes" $ \onTestFailureLog -> do
         inTempDirectory $ do
           writeHaskellProject repoDir
-          output <- runGarn ["run", "foo"] "" repoDir Nothing
+          output <- runGarn ["run", "foo.garn-test"] "" repoDir Nothing
           onTestFailureLog output
           flake <- readFile "./flake.nix"
           pure $ defaultGolden "generates_formatted_flakes" flake

--- a/test/spec/InitSpec.hs
+++ b/test/spec/InitSpec.hs
@@ -53,8 +53,8 @@ spec = do
 
               export const test = garn.haskell.mkHaskellProject({
                 description: "",
-                executable: "",
                 compiler: "ghc94",
+                executables: ["test"],
                 src: "."
               })
             |]

--- a/test/spec/RunSpec.hs
+++ b/test/spec/RunSpec.hs
@@ -24,13 +24,13 @@ spec =
       $ do
         it "runs a simple Haskell program" $ \onTestFailureLog -> do
           writeHaskellProject repoDir
-          output <- runGarn ["run", "foo"] "" repoDir Nothing
+          output <- runGarn ["run", "foo.garn-test"] "" repoDir Nothing
           onTestFailureLog output
           stdout output `shouldBe` "haskell test output\n"
         it "writes flake.{lock,nix}, but no other files" $ \onTestFailureLog -> do
           writeHaskellProject repoDir
           filesBefore <- listDirectory "."
-          output <- runGarn ["run", "foo"] "" repoDir Nothing
+          output <- runGarn ["run", "foo.garn-test"] "" repoDir Nothing
           onTestFailureLog output
           filesAfter <- sort <$> listDirectory "."
           filesAfter `shouldBe` sort (filesBefore ++ ["flake.lock", "flake.nix"])

--- a/test/spec/TestUtils.hs
+++ b/test/spec/TestUtils.hs
@@ -44,7 +44,7 @@ writeHaskellProject repoDir = do
 
       export const foo = mkHaskellProject({
         description: "mkHaskellProject-test",
-        executable: "garn-test",
+        executables: ["garn-test"],
         compiler: "ghc94",
         src: "."
       })

--- a/ts/deployToGhPages.test.ts
+++ b/ts/deployToGhPages.test.ts
@@ -86,7 +86,10 @@ describe("deployToGhPages", () => {
     gitRepo.run("commit", "-m", "Add some files");
     gitRepo.run("checkout", "main");
     assertSuccess(
-      runExecutable(project.deployToGhPages, { cwd: gitRepo.path, inSameDir: false }),
+      runExecutable(project.deployToGhPages, {
+        cwd: gitRepo.path,
+        inSameDir: false,
+      }),
     );
     gitRepo.run("checkout", "gh-pages");
     assertEquals(
@@ -113,7 +116,10 @@ describe("deployToGhPages", () => {
     gitRepo.run("add", "foo", ".hidden");
     gitRepo.run("commit", "-m", "Add some files");
     assertSuccess(
-      runExecutable(project.deployToGhPages, { cwd: gitRepo.path, inSameDir: false }),
+      runExecutable(project.deployToGhPages, {
+        cwd: gitRepo.path,
+        inSameDir: false,
+      }),
     );
     gitRepo.run("checkout", "gh-pages");
     assertEquals(
@@ -139,7 +145,10 @@ describe("deployToGhPages", () => {
       "some untracked content",
     );
     assertSuccess(
-      runExecutable(project.deployToGhPages, { cwd: gitRepo.path, inSameDir: false }),
+      runExecutable(project.deployToGhPages, {
+        cwd: gitRepo.path,
+        inSameDir: false,
+      }),
     );
     assertEquals(
       Array.from(Deno.readDirSync(gitRepo.path))

--- a/ts/deployToGhPages.test.ts
+++ b/ts/deployToGhPages.test.ts
@@ -28,7 +28,7 @@ const mkGitRepo = () => {
     );
     return output.stdout;
   };
-  run("init");
+  run("init", "--initial-branch=main");
   run("commit", "--allow-empty", "-m", "first commit");
   return { run, path };
 };
@@ -41,6 +41,7 @@ describe("deployToGhPages", () => {
     const output = assertSuccess(
       runExecutable(project.deployToGhPages, {
         cwd: gitRepo.path,
+        inSameDir: false,
       }),
     );
     assertMatch(
@@ -83,9 +84,9 @@ describe("deployToGhPages", () => {
     Deno.writeTextFileSync(`${gitRepo.path}/.hidden`, "some hidden content");
     gitRepo.run("add", "foo", ".hidden");
     gitRepo.run("commit", "-m", "Add some files");
-    gitRepo.run("checkout", "master");
+    gitRepo.run("checkout", "main");
     assertSuccess(
-      runExecutable(project.deployToGhPages, { cwd: gitRepo.path }),
+      runExecutable(project.deployToGhPages, { cwd: gitRepo.path, inSameDir: false }),
     );
     gitRepo.run("checkout", "gh-pages");
     assertEquals(
@@ -112,7 +113,7 @@ describe("deployToGhPages", () => {
     gitRepo.run("add", "foo", ".hidden");
     gitRepo.run("commit", "-m", "Add some files");
     assertSuccess(
-      runExecutable(project.deployToGhPages, { cwd: gitRepo.path }),
+      runExecutable(project.deployToGhPages, { cwd: gitRepo.path, inSameDir: false }),
     );
     gitRepo.run("checkout", "gh-pages");
     assertEquals(
@@ -138,7 +139,7 @@ describe("deployToGhPages", () => {
       "some untracked content",
     );
     assertSuccess(
-      runExecutable(project.deployToGhPages, { cwd: gitRepo.path }),
+      runExecutable(project.deployToGhPages, { cwd: gitRepo.path, inSameDir: false }),
     );
     assertEquals(
       Array.from(Deno.readDirSync(gitRepo.path))
@@ -153,6 +154,7 @@ describe("deployToGhPages", () => {
     gitRepo.run("checkout", "-b", "gh-pages");
     const output = runExecutable(project.deployToGhPages, {
       cwd: gitRepo.path,
+      inSameDir: false,
     });
     assertNotEquals(output.exitCode, 0);
     assertMatch(

--- a/ts/haskell/initializers.test.ts
+++ b/ts/haskell/initializers.test.ts
@@ -55,33 +55,30 @@ Deno.test(
   },
 );
 
-Deno.test(
-  "Haskell initializer includes executables",
-  () => {
-    const tempDir = Deno.makeTempDirSync();
-    Deno.writeTextFileSync(
-      join(tempDir, "foo.cabal"),
-      `
+Deno.test("Haskell initializer includes executables", () => {
+  const tempDir = Deno.makeTempDirSync();
+  Deno.writeTextFileSync(
+    join(tempDir, "foo.cabal"),
+    `
     name: foo
     version: 0.0.1
 
     executable bar
       main-is: Main.hs
   `,
-    );
-    const result = mkHaskellProjectInitializer(tempDir);
-    assertEquals(result.tag, "ShouldRun");
-    if (result.tag === "ShouldRun") {
-      assertEquals(
-        result.makeTarget(),
-        outdent`
+  );
+  const result = mkHaskellProjectInitializer(tempDir);
+  assertEquals(result.tag, "ShouldRun");
+  if (result.tag === "ShouldRun") {
+    assertEquals(
+      result.makeTarget(),
+      outdent`
           export const foo = garn.haskell.mkHaskellProject({
             description: "",
             compiler: "ghc94",
             executables: ["bar"],
             src: "."
           })`,
-      );
-    }
+    );
   }
-)
+});

--- a/ts/haskell/initializers.test.ts
+++ b/ts/haskell/initializers.test.ts
@@ -60,12 +60,12 @@ Deno.test("Haskell initializer includes executables", () => {
   Deno.writeTextFileSync(
     join(tempDir, "foo.cabal"),
     `
-    name: foo
-    version: 0.0.1
+      name: foo
+      version: 0.0.1
 
-    executable bar
-      main-is: Main.hs
-  `,
+      executable bar
+        main-is: Main.hs
+    `,
   );
   const result = mkHaskellProjectInitializer(tempDir);
   assertEquals(result.tag, "ShouldRun");

--- a/ts/haskell/initializers.test.ts
+++ b/ts/haskell/initializers.test.ts
@@ -46,7 +46,6 @@ Deno.test(
         outdent`
           export const foo = garn.haskell.mkHaskellProject({
             description: "",
-            executable: "",
             compiler: "ghc94",
             src: "."
           })`,
@@ -54,3 +53,33 @@ Deno.test(
     }
   },
 );
+
+Deno.test(
+  "Haskell initializer includes executables",
+  () => {
+    const tempDir = Deno.makeTempDirSync();
+    Deno.writeTextFileSync(
+      join(tempDir, "foo.cabal"),
+      `
+    name: foo
+    version: 0.0.1
+
+    executable bar
+      main-is: Main.hs
+  `,
+    );
+    const result = mkHaskellProjectInitializer(tempDir);
+    assertEquals(result.tag, "ShouldRun");
+    if (result.tag === "ShouldRun") {
+      assertEquals(
+        result.makeTarget(),
+        outdent`
+          export const foo = garn.haskell.mkHaskellProject({
+            description: "",
+            compiler: "ghc94",
+            src: "."
+          }).withCabalExecutable("bar")`,
+      );
+    }
+  }
+)

--- a/ts/haskell/initializers.test.ts
+++ b/ts/haskell/initializers.test.ts
@@ -47,6 +47,7 @@ Deno.test(
           export const foo = garn.haskell.mkHaskellProject({
             description: "",
             compiler: "ghc94",
+            executables: [],
             src: "."
           })`,
       );
@@ -77,8 +78,9 @@ Deno.test(
           export const foo = garn.haskell.mkHaskellProject({
             description: "",
             compiler: "ghc94",
+            executables: ["bar"],
             src: "."
-          }).withCabalExecutable("bar")`,
+          })`,
       );
     }
   }

--- a/ts/haskell/initializers.ts
+++ b/ts/haskell/initializers.ts
@@ -31,7 +31,7 @@ export const mkHaskellProjectInitializer: Initializer = (dir) => {
 
   const executables = parsedCabal.executables
     ? `\n  executables: ${JSON.stringify(parsedCabal.executables)},`
-    : ""
+    : "";
   return {
     tag: "ShouldRun",
     makeTarget: () =>

--- a/ts/haskell/initializers.ts
+++ b/ts/haskell/initializers.ts
@@ -30,9 +30,7 @@ export const mkHaskellProjectInitializer: Initializer = (dir) => {
   const parsedCabal = JSON.parse(decoder.decode(jsonParseResult.stdout));
 
   const executables = parsedCabal.executables
-    ? parsedCabal.executables.reduce(
-      (prev : string, cur : string) => `${prev}.withCabalExecutable("${cur}")`,
-      "")
+    ? `\n  executables: ${JSON.stringify(parsedCabal.executables)},`
     : ""
   return {
     tag: "ShouldRun",
@@ -40,9 +38,9 @@ export const mkHaskellProjectInitializer: Initializer = (dir) => {
       outdent`
       export const ${parsedCabal.name} = garn.haskell.mkHaskellProject({
         description: "${parsedCabal.synopsis || parsedCabal.description || ""}",
-        compiler: "ghc94",
+        compiler: "ghc94",${executables}
         src: "."
-      })${executables}`,
+      })`,
   };
 };
 

--- a/ts/haskell/initializers.ts
+++ b/ts/haskell/initializers.ts
@@ -29,16 +29,20 @@ export const mkHaskellProjectInitializer: Initializer = (dir) => {
   }
   const parsedCabal = JSON.parse(decoder.decode(jsonParseResult.stdout));
 
+  const executables = parsedCabal.executables
+    ? parsedCabal.executables.reduce(
+      (prev : string, cur : string) => `${prev}.withCabalExecutable("${cur}")`,
+      "")
+    : ""
   return {
     tag: "ShouldRun",
     makeTarget: () =>
       outdent`
       export const ${parsedCabal.name} = garn.haskell.mkHaskellProject({
         description: "${parsedCabal.synopsis || parsedCabal.description || ""}",
-        executable: "",
         compiler: "ghc94",
         src: "."
-      })`,
+      })${executables}`,
   };
 };
 

--- a/ts/haskell/mod.test.ts
+++ b/ts/haskell/mod.test.ts
@@ -15,7 +15,7 @@ describe("mkHaskellProject", () => {
               main-is: Main.hs
               build-depends: base
               default-language: Haskell2010
-          `,
+        `,
       );
       Deno.writeTextFileSync(
         `${path}/Main.hs`,

--- a/ts/haskell/mod.test.ts
+++ b/ts/haskell/mod.test.ts
@@ -1,0 +1,37 @@
+import { describe, it } from "https://deno.land/std@0.206.0/testing/bdd.ts";
+import * as haskell from "./mod.ts";
+import { assertStdout, assertSuccess, assertStderr, runExecutable } from "../testUtils.ts";
+
+describe("mkHaskellProject", () => {
+  describe("addCabalExecutable", () => {
+    it("allows adding existing cabal executables with .addCabalExecutable", () => {
+      const path = Deno.makeTempDirSync();
+      Deno.writeTextFileSync(
+          `${path}/project.cabal`,
+          `
+            name: project
+            version: 0.0.1
+            executable foo
+              main-is: Main.hs
+              build-depends: base
+              default-language: Haskell2010
+          `
+      );
+      Deno.writeTextFileSync(
+          `${path}/Main.hs`,
+          `
+            main = putStrLn "yo"
+          `
+      );
+      const project = haskell
+        .mkHaskellProject({
+            description: "",
+            compiler: "ghc94",
+            src: ".",
+        }).addCabalExecutable("foo");
+      const output = runExecutable(project.foo, {cwd: path});
+      assertSuccess(output);
+      assertStdout(output, "yo\n");
+    });
+  });
+})

--- a/ts/haskell/mod.test.ts
+++ b/ts/haskell/mod.test.ts
@@ -3,7 +3,6 @@ import * as haskell from "./mod.ts";
 import {
   assertStdout,
   assertSuccess,
-  assertStderr,
   runExecutable,
 } from "../testUtils.ts";
 

--- a/ts/haskell/mod.test.ts
+++ b/ts/haskell/mod.test.ts
@@ -1,10 +1,6 @@
 import { describe, it } from "https://deno.land/std@0.206.0/testing/bdd.ts";
 import * as haskell from "./mod.ts";
-import {
-  assertStdout,
-  assertSuccess,
-  runExecutable,
-} from "../testUtils.ts";
+import { assertStdout, assertSuccess, runExecutable } from "../testUtils.ts";
 
 describe("mkHaskellProject", () => {
   describe("addCabalExecutable", () => {

--- a/ts/haskell/mod.test.ts
+++ b/ts/haskell/mod.test.ts
@@ -1,37 +1,43 @@
 import { describe, it } from "https://deno.land/std@0.206.0/testing/bdd.ts";
 import * as haskell from "./mod.ts";
-import { assertStdout, assertSuccess, assertStderr, runExecutable } from "../testUtils.ts";
+import {
+  assertStdout,
+  assertSuccess,
+  assertStderr,
+  runExecutable,
+} from "../testUtils.ts";
 
 describe("mkHaskellProject", () => {
   describe("addCabalExecutable", () => {
     it("allows adding existing cabal executables with .addCabalExecutable", () => {
       const path = Deno.makeTempDirSync();
       Deno.writeTextFileSync(
-          `${path}/project.cabal`,
-          `
+        `${path}/project.cabal`,
+        `
             name: project
             version: 0.0.1
             executable foo
               main-is: Main.hs
               build-depends: base
               default-language: Haskell2010
-          `
+          `,
       );
       Deno.writeTextFileSync(
-          `${path}/Main.hs`,
-          `
+        `${path}/Main.hs`,
+        `
             main = putStrLn "yo"
-          `
+          `,
       );
       const project = haskell
         .mkHaskellProject({
-            description: "",
-            compiler: "ghc94",
-            src: ".",
-        }).addCabalExecutable("foo");
-      const output = runExecutable(project.foo, {cwd: path});
+          description: "",
+          compiler: "ghc94",
+          src: ".",
+        })
+        .addCabalExecutable("foo");
+      const output = runExecutable(project.foo, { cwd: path });
       assertSuccess(output);
       assertStdout(output, "yo\n");
     });
   });
-})
+});

--- a/ts/haskell/mod.test.ts
+++ b/ts/haskell/mod.test.ts
@@ -21,7 +21,7 @@ describe("mkHaskellProject", () => {
         `${path}/Main.hs`,
         `
             main = putStrLn "yo"
-          `,
+        `,
       );
       const project = haskell
         .mkHaskellProject({

--- a/ts/haskell/mod.ts
+++ b/ts/haskell/mod.ts
@@ -13,18 +13,18 @@ export type HaskellAddenda = {
    * A package building the entire Haskell project
    */
   pkg: Package;
-   /**
-    * Make an executable from the cabal file available to garn.
-    */
-   addCabalExecutable: <T extends Project & HaskellAddenda, Name extends string>(
-     this: T,
-     executableName: Name,
-   ) => Omit<T, Name> & { [n in Name]: Executable };
+  /**
+   * Make an executable from the cabal file available to garn.
+   */
+  addCabalExecutable: <T extends Project & HaskellAddenda, Name extends string>(
+    this: T,
+    executableName: Name,
+  ) => Omit<T, Name> & { [n in Name]: Executable };
 };
 
 type Execs<Exe extends string[]> = {
   [e in Exe[number]]: Executable;
-}
+};
 
 /**
  * Creates a haskell-based garn Project.
@@ -61,9 +61,9 @@ export function mkHaskellProject<const Executables extends string[]>(args: {
     ? args.executables.reduce((prev, cur) => {
         return { ...prev, [cur]: defaultEnvironment.shell`${pkg}/bin/${cur}` };
       }, {} as Execs<Executables>)
-    : {} as Execs<Executables>;
+    : ({} as Execs<Executables>);
 
-  const projectBase  = mkProject(
+  const projectBase = mkProject(
     {
       description: args.description,
       defaultEnvironment: defaultEnvironment,

--- a/ts/haskell/mod.ts
+++ b/ts/haskell/mod.ts
@@ -5,7 +5,6 @@ import { Executable } from "../executable.ts";
 import { nixSource } from "../internal/utils.ts";
 import { nixRaw } from "../nix.ts";
 
-
 /**
  * Project components returned by `mkHaskellProject`
  */
@@ -13,14 +12,15 @@ export type HaskellAddenda = {
   /**
    * A package building the entire Haskell project
    */
-  pkg: Package
+  pkg: Package;
   /**
    * Make an executable from the cabal file available to garn.
    */
-  addCabalExecutable:<T extends Project & HaskellAddenda, Name extends string>(this: T, executableName : Name) =>
-    Omit<T, Name> & { [n in Name] : Executable }
-}
-
+  addCabalExecutable: <T extends Project & HaskellAddenda, Name extends string>(
+    this: T,
+    executableName: Name,
+  ) => Omit<T, Name> & { [n in Name]: Executable };
+};
 
 /**
  * Creates a haskell-based garn Project.
@@ -38,7 +38,7 @@ export type HaskellAddenda = {
 export function mkHaskellProject(args: {
   description: string;
   compiler: string;
-  executables?: string[],
+  executables?: string[];
   src: string;
 }): Project & HaskellAddenda {
   const pkg: Package = mkPackage(
@@ -53,11 +53,11 @@ export function mkHaskellProject(args: {
 
   const defaultEnvironment = packageToEnvironment(pkg, args.src);
 
-  const execs = args.executables ? args.executables.reduce<Record<string,Nestable>>(
-          (prev, cur) => {
-              return {...prev, [cur]: defaultEnvironment.shell`${pkg}/bin/${cur}`}
-          }, {})
-        : {}
+  const execs = args.executables
+    ? args.executables.reduce<Record<string, Nestable>>((prev, cur) => {
+        return { ...prev, [cur]: defaultEnvironment.shell`${pkg}/bin/${cur}` };
+      }, {})
+    : {};
 
   const projectBase = mkProject(
     {
@@ -66,7 +66,7 @@ export function mkHaskellProject(args: {
     },
     {
       pkg,
-      ...execs
+      ...execs,
     },
   ).withDevTools([
     mkPackage(
@@ -77,11 +77,13 @@ export function mkHaskellProject(args: {
 
   return {
     ...projectBase,
-    addCabalExecutable: function<
+    addCabalExecutable: function <
       T extends Project & HaskellAddenda,
-      Name extends string
+      Name extends string,
     >(this: T, executableName: Name) {
-        return this.addExecutable(executableName)`${this.pkg}/bin/${executableName}`
-    }
-  }
+      return this.addExecutable(
+        executableName,
+      )`${this.pkg}/bin/${executableName}`;
+    },
+  };
 }

--- a/ts/project.ts
+++ b/ts/project.ts
@@ -189,7 +189,7 @@ export function isProject(p: unknown): p is Project {
   return hasTag(p, "project");
 }
 
-type Nestable = Environment | Package | Executable | Check | Project;
+export type Nestable = Environment | Package | Executable | Check | Project;
 
 /**
  * Creates a new `Project`.

--- a/ts/testUtils.ts
+++ b/ts/testUtils.ts
@@ -60,7 +60,7 @@ export const runExecutable = (
   executable: garn.Executable,
   options: { cwd?: string } = {},
 ): Output => {
-  const tempDir = Deno.makeTempDirSync({ prefix: "garn-test" });
+  const tempDir = options.cwd ? options.cwd : Deno.makeTempDirSync({ prefix: "garn-test" });
   const nixpkgsInput = nix.nixFlakeDep("nixpkgs-repo", {
     url: "github:NixOS/nixpkgs/6fc7203e423bbf1c8f84cccf1c4818d097612566",
   });

--- a/ts/testUtils.ts
+++ b/ts/testUtils.ts
@@ -56,11 +56,18 @@ export const assertStderr = (output: Output, expected: string) => {
   }
 };
 
+/*
+ * Run an Executable. If `cwd` is set, run the `nix run` command from that
+ * directory, which is also where the flake file is generated (unless
+ * `inSameDir` is `false`).
+ */
 export const runExecutable = (
   executable: garn.Executable,
-  options: { cwd?: string } = {},
+  options: { cwd?: string, inSameDir?: boolean} = {},
 ): Output => {
-  const tempDir = options.cwd
+  const inSameDir = options.inSameDir == undefined ? true : options.inSameDir;
+
+  const tempDir = options.cwd && inSameDir
     ? options.cwd
     : Deno.makeTempDirSync({ prefix: "garn-test" });
   const nixpkgsInput = nix.nixFlakeDep("nixpkgs-repo", {

--- a/ts/testUtils.ts
+++ b/ts/testUtils.ts
@@ -63,13 +63,14 @@ export const assertStderr = (output: Output, expected: string) => {
  */
 export const runExecutable = (
   executable: garn.Executable,
-  options: { cwd?: string, inSameDir?: boolean} = {},
+  options: { cwd?: string; inSameDir?: boolean } = {},
 ): Output => {
   const inSameDir = options.inSameDir == undefined ? true : options.inSameDir;
 
-  const tempDir = options.cwd && inSameDir
-    ? options.cwd
-    : Deno.makeTempDirSync({ prefix: "garn-test" });
+  const tempDir =
+    options.cwd && inSameDir
+      ? options.cwd
+      : Deno.makeTempDirSync({ prefix: "garn-test" });
   const nixpkgsInput = nix.nixFlakeDep("nixpkgs-repo", {
     url: "github:NixOS/nixpkgs/6fc7203e423bbf1c8f84cccf1c4818d097612566",
   });

--- a/ts/testUtils.ts
+++ b/ts/testUtils.ts
@@ -60,7 +60,9 @@ export const runExecutable = (
   executable: garn.Executable,
   options: { cwd?: string } = {},
 ): Output => {
-  const tempDir = options.cwd ? options.cwd : Deno.makeTempDirSync({ prefix: "garn-test" });
+  const tempDir = options.cwd
+    ? options.cwd
+    : Deno.makeTempDirSync({ prefix: "garn-test" });
   const nixpkgsInput = nix.nixFlakeDep("nixpkgs-repo", {
     url: "github:NixOS/nixpkgs/6fc7203e423bbf1c8f84cccf1c4818d097612566",
   });


### PR DESCRIPTION
Previously you *had* to define an executable, and there was only one allowed. This enables multiple ones or none, and also deduces them from the cabal file in the initializer.

You can both specify the executables with the options `executables` field (which is now also a list), or after the fact with `addCabalExecutable`. 
 

Fixes #395 in its way.