### PR TITLE
Remove LC_ALL export from garn wrapper script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.0.17 (unreleased)
 
+- Fix locale warnings on MacOS
+
 ## v0.0.16
 
 - Allow to build packages that are nested within projects with `garn build projectName.packageName`.

--- a/flake.nix
+++ b/flake.nix
@@ -47,7 +47,6 @@
                 mkdir -p $out/bin
                 cp ${garnHaskellPackage}/bin/garn $out/bin
                 wrapProgram "$out/bin/garn" \
-                    --set LC_ALL C.UTF-8 \
                     --prefix PATH : ${pkgs.lib.makeBinPath [
                   pkgs.coreutils
                   pkgs.deno


### PR DESCRIPTION
@soenkehahn and I did some more testing and didn't find any regressions with this change. I think for now it's probably best to omit this since ideally on both MacOS and Linux you have your `$LANG` set appropriately (but even if you don't have it set garn seems to work).

Resolves #403 