### PR TITLE
Allow to pass `src` to `mkEnvironment`

### DIFF
--- a/examples/frontend-create-react-app/flake.nix
+++ b/examples/frontend-create-react-app/flake.nix
@@ -66,8 +66,9 @@
     #!\${pkgs.bash}/bin/bash
     mkdir \$out
     ${"
-      echo copying source
-      cp -r ${(let
+      ${"
+    echo copying source
+    cp -r ${(let
     lib = pkgs.lib;
     lastSafe = list :
       if lib.lists.length list == 0
@@ -85,8 +86,10 @@
          fileName != "flake.nix" &&
          fileName != "garn.ts";
     })} src
-      chmod -R u+rwX src
-      cd src
+    chmod -R u+rwX src
+    cd src
+  "}
+      ${"
       echo copying node_modules
       cp -r ${let
         npmlock2nix = import npmlock2nix-repo {
@@ -120,6 +123,7 @@
           nodejs = pkgs.nodejs-18_x;
         }}/node_modules .
       chmod -R u+rwX node_modules
+    "}
     "}
     ${"npm run build && mv build/* \$out"}
   ";

--- a/examples/getting-started/flake.nix
+++ b/examples/getting-started/flake.nix
@@ -17,7 +17,7 @@
           };
         in
         {
-          "backend_pkg" =
+          "backend/pkg" =
             let
               gomod2nix = gomod2nix-repo.legacyPackages.${system};
               gomod2nix-toml = pkgs.writeText "gomod2nix-toml" "schema = 3
@@ -51,7 +51,7 @@
               );
               modules = gomod2nix-toml;
             };
-          "frontend_node_modules" =
+          "frontend/node_modules" =
             let
               npmlock2nix = import npmlock2nix-repo {
                 inherit pkgs;
@@ -95,7 +95,7 @@
           };
         in
         {
-          "frontend_test" =
+          "frontend/test" =
             let
               dev = (pkgs.mkShell { }).overrideAttrs (finalAttrs: previousAttrs: {
                 nativeBuildInputs =
@@ -108,8 +108,8 @@
               {
                 buildInputs = dev.buildInputs ++ dev.nativeBuildInputs;
               } "
-      touch \$out
-      ${"
+    touch \$out
+    ${"
       echo copying source
       cp -r ${(let
     lib = pkgs.lib;
@@ -133,17 +133,17 @@
       cd src
       echo copying node_modules
       cp -r ${let
-      npmlock2nix = import npmlock2nix-repo {
-        inherit pkgs;
-      };
-      pkgs = import "${nixpkgs}" {
+        npmlock2nix = import npmlock2nix-repo {
+          inherit pkgs;
+        };
+        pkgs = import "${nixpkgs}" {
         config.permittedInsecurePackages = [];
         inherit system;
       };
-    in
-    npmlock2nix.v2.node_modules
-      {
-        src = (let
+      in
+      npmlock2nix.v2.node_modules
+        {
+          src = (let
     lib = pkgs.lib;
     lastSafe = list :
       if lib.lists.length list == 0
@@ -161,12 +161,12 @@
          fileName != "flake.nix" &&
          fileName != "garn.ts";
     });
-        nodejs = pkgs.nodejs-18_x;
-      }}/node_modules .
+          nodejs = pkgs.nodejs-18_x;
+        }}/node_modules .
       chmod -R u+rwX node_modules
     "}
-      ${"npm test"}
-    ";
+    ${"npm test"}
+  ";
         }
       );
       devShells = forAllSystems (system:
@@ -240,7 +240,10 @@
       );
       apps = forAllSystems (system:
         let
-          pkgs = import "${nixpkgs}" { inherit system; };
+          pkgs = import "${nixpkgs}" {
+            config.allowUnfree = true;
+            inherit system;
+          };
         in
         {
           "edit" = {
@@ -254,13 +257,13 @@
 
     # copy the vscodium config
     cp -r ${let dev = pkgs.mkShell {}; in
-      pkgs.runCommand "garn-pkg" {
-        buildInputs = dev.buildInputs ++ dev.nativeBuildInputs;
-      } "
-      #!\${pkgs.bash}/bin/bash
-      mkdir \$out
-      ${""}
-      ${"
+    pkgs.runCommand "garn-pkg" {
+      buildInputs = dev.buildInputs ++ dev.nativeBuildInputs;
+    } "
+    #!\${pkgs.bash}/bin/bash
+    mkdir \$out
+    ${""}
+    ${"
     USER_CONFIG=.config/VSCodium/User
     if test \$(uname) = \"Darwin\" ; then
       USER_CONFIG=\"Library/Application Support/VSCodium/User\"
@@ -282,13 +285,13 @@
   }} \"\$out/\$USER_CONFIG/settings.json\"
     mkdir -p \"\$out/\$USER_CONFIG/globalStorage\"
     cp ${let dev = pkgs.mkShell {}; in
-      pkgs.runCommand "garn-pkg" {
-        buildInputs = dev.buildInputs ++ dev.nativeBuildInputs;
-      } "
-      #!\${pkgs.bash}/bin/bash
-      mkdir \$out
-      ${""}
-      ${"
+    pkgs.runCommand "garn-pkg" {
+      buildInputs = dev.buildInputs ++ dev.nativeBuildInputs;
+    } "
+    #!\${pkgs.bash}/bin/bash
+    mkdir \$out
+    ${""}
+    ${"
     set -euo pipefail
     cat ${pkgs.writeTextFile {
     name = "${"sqlite-script"}";
@@ -299,9 +302,9 @@ INSERT INTO ItemTable VALUES('denoland.vscode-deno','{\"deno.welcomeShown\":true
 COMMIT;"}";
   }} | ${pkgs.sqlite}/bin/sqlite3 \$out/state.vscdb
   "}
-    "}/state.vscdb \"\$out/\$USER_CONFIG/globalStorage/state.vscdb\"
+  "}/state.vscdb \"\$out/\$USER_CONFIG/globalStorage/state.vscdb\"
   "}
-    "}/. \$TEMP_DIR
+  "}/. \$TEMP_DIR
     chmod -R u+rwX \$TEMP_DIR
 
     # copy the deno cache

--- a/examples/go-http-backend/flake.nix
+++ b/examples/go-http-backend/flake.nix
@@ -169,11 +169,11 @@
     });
           modules = gomod2nix-toml;
         };
-    in
-      (if expr ? env
-        then expr.env
-        else pkgs.mkShell { inputsFrom = [ expr ]; }
-      )).overrideAttrs (finalAttrs: previousAttrs: {
+        in
+          (if expr ? env
+            then expr.env
+            else pkgs.mkShell { inputsFrom = [ expr ]; }
+          )).overrideAttrs (finalAttrs: previousAttrs: {
           nativeBuildInputs =
             previousAttrs.nativeBuildInputs
             ++
@@ -228,11 +228,11 @@
     });
           modules = gomod2nix-toml;
         };
-    in
-      (if expr ? env
-        then expr.env
-        else pkgs.mkShell { inputsFrom = [ expr ]; }
-      )).overrideAttrs (finalAttrs: previousAttrs: {
+        in
+          (if expr ? env
+            then expr.env
+            else pkgs.mkShell { inputsFrom = [ expr ]; }
+          )).overrideAttrs (finalAttrs: previousAttrs: {
           nativeBuildInputs =
             previousAttrs.nativeBuildInputs
             ++

--- a/examples/haskell/flake.nix
+++ b/examples/haskell/flake.nix
@@ -98,8 +98,8 @@
               } "
     touch \$out
     ${"
-      echo copying source
-      cp -r ${(let
+        echo copying source
+        cp -r ${(let
     lib = pkgs.lib;
     lastSafe = list :
       if lib.lists.length list == 0
@@ -117,9 +117,9 @@
          fileName != "flake.nix" &&
          fileName != "garn.ts";
     })} src
-      chmod -R u+rwX src
-      cd src
-    "}
+        chmod -R u+rwX src
+        cd src
+      "}
     ${"hlint *.hs"}
   ";
         }

--- a/examples/haskell/flake.nix
+++ b/examples/haskell/flake.nix
@@ -98,8 +98,9 @@
               } "
     touch \$out
     ${"
-        echo copying source
-        cp -r ${(let
+      ${"
+    echo copying source
+    cp -r ${(let
     lib = pkgs.lib;
     lastSafe = list :
       if lib.lists.length list == 0
@@ -117,9 +118,11 @@
          fileName != "flake.nix" &&
          fileName != "garn.ts";
     })} src
-        chmod -R u+rwX src
-        cd src
-      "}
+    chmod -R u+rwX src
+    cd src
+  "}
+      ${""}
+    "}
     ${"hlint *.hs"}
   ";
         }

--- a/examples/monorepo/flake.nix
+++ b/examples/monorepo/flake.nix
@@ -269,11 +269,11 @@
     });
           modules = gomod2nix-toml;
         };
-    in
-      (if expr ? env
-        then expr.env
-        else pkgs.mkShell { inputsFrom = [ expr ]; }
-      )).overrideAttrs (finalAttrs: previousAttrs: {
+        in
+          (if expr ? env
+            then expr.env
+            else pkgs.mkShell { inputsFrom = [ expr ]; }
+          )).overrideAttrs (finalAttrs: previousAttrs: {
           nativeBuildInputs =
             previousAttrs.nativeBuildInputs
             ++
@@ -412,11 +412,11 @@
     });
           modules = gomod2nix-toml;
         };
-    in
-      (if expr ? env
-        then expr.env
-        else pkgs.mkShell { inputsFrom = [ expr ]; }
-      )).overrideAttrs (finalAttrs: previousAttrs: {
+        in
+          (if expr ? env
+            then expr.env
+            else pkgs.mkShell { inputsFrom = [ expr ]; }
+          )).overrideAttrs (finalAttrs: previousAttrs: {
           nativeBuildInputs =
             previousAttrs.nativeBuildInputs
             ++

--- a/examples/npm-project/flake.nix
+++ b/examples/npm-project/flake.nix
@@ -75,8 +75,9 @@
               } "
     touch \$out
     ${"
-      echo copying source
-      cp -r ${(let
+      ${"
+    echo copying source
+    cp -r ${(let
     lib = pkgs.lib;
     lastSafe = list :
       if lib.lists.length list == 0
@@ -94,8 +95,10 @@
          fileName != "flake.nix" &&
          fileName != "garn.ts";
     })} src
-      chmod -R u+rwX src
-      cd src
+    chmod -R u+rwX src
+    cd src
+  "}
+      ${"
       echo copying node_modules
       cp -r ${let
         npmlock2nix = import npmlock2nix-repo {
@@ -130,6 +133,7 @@
         }}/node_modules .
       chmod -R u+rwX node_modules
     "}
+    "}
     ${"npm run test"}
   ";
           "project/tsc" =
@@ -147,8 +151,9 @@
               } "
     touch \$out
     ${"
-      echo copying source
-      cp -r ${(let
+      ${"
+    echo copying source
+    cp -r ${(let
     lib = pkgs.lib;
     lastSafe = list :
       if lib.lists.length list == 0
@@ -166,8 +171,10 @@
          fileName != "flake.nix" &&
          fileName != "garn.ts";
     })} src
-      chmod -R u+rwX src
-      cd src
+    chmod -R u+rwX src
+    cd src
+  "}
+      ${"
       echo copying node_modules
       cp -r ${let
         npmlock2nix = import npmlock2nix-repo {
@@ -201,6 +208,7 @@
           nodejs = pkgs.nodejs-18_x;
         }}/node_modules .
       chmod -R u+rwX node_modules
+    "}
     "}
     ${"npm run tsc"}
   ";

--- a/examples/vite-frontend/flake.nix
+++ b/examples/vite-frontend/flake.nix
@@ -66,8 +66,9 @@
     #!\${pkgs.bash}/bin/bash
     mkdir \$out
     ${"
-      echo copying source
-      cp -r ${(let
+      ${"
+    echo copying source
+    cp -r ${(let
     lib = pkgs.lib;
     lastSafe = list :
       if lib.lists.length list == 0
@@ -85,8 +86,10 @@
          fileName != "flake.nix" &&
          fileName != "garn.ts";
     })} src
-      chmod -R u+rwX src
-      cd src
+    chmod -R u+rwX src
+    cd src
+  "}
+      ${"
       echo copying node_modules
       cp -r ${let
         npmlock2nix = import npmlock2nix-repo {
@@ -120,6 +123,7 @@
           nodejs = pkgs.nodejs-18_x;
         }}/node_modules .
       chmod -R u+rwX node_modules
+    "}
     "}
     ${"
       set -eu

--- a/test/spec/BuildSpec.hs
+++ b/test/spec/BuildSpec.hs
@@ -114,10 +114,12 @@ spec = do
             [i|
               import * as garn from "#{repoDir}/ts/mod.ts"
 
-              const env = garn.mkEnvironment(undefined, garn.nix.nixStrLit`
-                mkdir dist
-                echo build-content > dist/build-artifact
-              `);
+              const env = garn.mkEnvironment({
+                setup: garn.nix.nixStrLit`
+                  mkdir dist
+                  echo build-content > dist/build-artifact
+                `
+              });
               export const project = garn.mkProject({
                 description: "",
                 defaultEnvironment: env,
@@ -179,10 +181,9 @@ spec = do
                 { description: "" },
                 {
                   package: garn
-                    .mkEnvironment(
-                      undefined,
-                      nix.nixStrLit`SETUP_VAR="hello from setup"`,
-                    )
+                    .mkEnvironment({
+                      setup: nix.nixStrLit`SETUP_VAR="hello from setup"`,
+                    })
                     .build("echo $SETUP_VAR > $out/build-artifact"),
                 },
               )

--- a/ts/environment.test.ts
+++ b/ts/environment.test.ts
@@ -13,19 +13,19 @@ import {
 import { assertStringIncludes } from "https://deno.land/std@0.206.0/assert/assert_string_includes.ts";
 
 describe("environments", () => {
-  it("allows to create Executables from shell snippets", () => {
+  it("allows creating Executables from shell snippets", () => {
     const env = garn.emptyEnvironment;
     const output = assertSuccess(runExecutable(env.shell("echo foo")));
     assertStdout(output, "foo\n");
   });
 
-  it("allows to add tools", () => {
+  it("allows adding tools", () => {
     const env = garn.emptyEnvironment.withDevTools([testPkgs.hello]);
     const output = assertSuccess(runExecutable(env.shell("hello")));
     assertStdout(output, "Hello, world!\n");
   });
 
-  it("allows to create Checks from shell snippets", () => {
+  it("allows creating Checks from shell snippets", () => {
     const env = garn.emptyEnvironment;
     const output = runCheck(env.check("echo test check output ; exit 1"));
     assertEquals(output.exitCode, 1);
@@ -36,7 +36,7 @@ describe("environments", () => {
   });
 
   describe("environments with source files", () => {
-    it("allows to access source files in Checks", () => {
+    it("allows accessing source files in Checks", () => {
       const src = Deno.makeTempDirSync();
       Deno.writeTextFileSync(`${src}/file`, "test source file");
       const env = garn.mkEnvironment({ src: "." });
@@ -55,7 +55,7 @@ describe("environments", () => {
       });
     });
 
-    it("allows to access source files in Packages", () => {
+    it("allows accessing source files in Packages", () => {
       const src = Deno.makeTempDirSync();
       Deno.writeTextFileSync(`${src}/file`, "test source file");
       const env = garn.mkEnvironment({ src: "." });

--- a/ts/environment.test.ts
+++ b/ts/environment.test.ts
@@ -7,7 +7,7 @@ import {
   runExecutable,
   assertStdout,
   runCheck,
-  assertOnOutput,
+  printOutputOnFailure,
   buildPackage,
 } from "./testUtils.ts";
 import { assertStringIncludes } from "https://deno.land/std@0.206.0/assert/assert_string_includes.ts";
@@ -30,7 +30,7 @@ describe("environments", () => {
     const output = runCheck(env.check("echo test check output ; exit 1"));
     assertEquals(output.exitCode, 1);
     assertStdout(output, "");
-    assertOnOutput(output, () =>
+    printOutputOnFailure(output, () =>
       assertStringIncludes(output.stderr, "test check output"),
     );
   });
@@ -49,7 +49,7 @@ describe("environments", () => {
           { dir: src },
         ),
       );
-      assertOnOutput(output, () => {
+      printOutputOnFailure(output, () => {
         assertStringIncludes(output.stderr, "copying source\n");
         assertStringIncludes(output.stderr, "test source file\n");
       });

--- a/ts/environment.test.ts
+++ b/ts/environment.test.ts
@@ -1,0 +1,22 @@
+import { describe, it } from "https://deno.land/std@0.206.0/testing/bdd.ts";
+import * as garn from "./mod.ts";
+import {
+  testPkgs,
+  assertSuccess,
+  runExecutable,
+  assertStdout,
+} from "./testUtils.ts";
+
+describe("environments", () => {
+  it("allows to create Executables from shell snippets", () => {
+    const env = garn.emptyEnvironment;
+    const output = assertSuccess(runExecutable(env.shell("echo foo")));
+    assertStdout(output, "foo\n");
+  });
+
+  it("allows to add tools", () => {
+    const env = garn.emptyEnvironment.withDevTools([testPkgs.hello]);
+    const output = assertSuccess(runExecutable(env.shell("hello")));
+    assertStdout(output, "Hello, world!\n");
+  });
+});

--- a/ts/environment.test.ts
+++ b/ts/environment.test.ts
@@ -1,11 +1,15 @@
 import { describe, it } from "https://deno.land/std@0.206.0/testing/bdd.ts";
+import { assertEquals } from "https://deno.land/std@0.206.0/assert/mod.ts";
 import * as garn from "./mod.ts";
 import {
   testPkgs,
   assertSuccess,
   runExecutable,
   assertStdout,
+  runCheck,
+  assertOnOutput,
 } from "./testUtils.ts";
+import { assertStringIncludes } from "https://deno.land/std@0.206.0/assert/assert_string_includes.ts";
 
 describe("environments", () => {
   it("allows to create Executables from shell snippets", () => {
@@ -18,5 +22,15 @@ describe("environments", () => {
     const env = garn.emptyEnvironment.withDevTools([testPkgs.hello]);
     const output = assertSuccess(runExecutable(env.shell("hello")));
     assertStdout(output, "Hello, world!\n");
+  });
+
+  it("allows to create Checks from shell snippets", () => {
+    const env = garn.emptyEnvironment;
+    const output = runCheck(env.check("echo test check output ; exit 1"));
+    assertEquals(output.exitCode, 1);
+    assertStdout(output, "");
+    assertOnOutput(output, () =>
+      assertStringIncludes(output.stderr, "test check output"),
+    );
   });
 });

--- a/ts/environment.test.ts
+++ b/ts/environment.test.ts
@@ -46,7 +46,7 @@ describe("environments", () => {
             # ${Date.now()}
             cat file
           `),
-          { tempDir: src },
+          { dir: src },
         ),
       );
       assertOnOutput(output, () => {
@@ -64,7 +64,7 @@ describe("environments", () => {
             echo -n built: >> $out/artifact
             cat file >> $out/artifact
           `),
-        { tempDir: src },
+        { dir: src },
       );
       assertEquals(
         Deno.readTextFileSync(`${output}/artifact`),

--- a/ts/javascript/mod.ts
+++ b/ts/javascript/mod.ts
@@ -80,18 +80,14 @@ export function mkNpmProject(args: {
     `,
     "node_modules",
   );
-  const devShell: Environment = mkEnvironment(
-    undefined,
-    nixStrLit`
-      echo copying source
-      cp -r ${nixSource(args.src)} src
-      chmod -R u+rwX src
-      cd src
+  const devShell: Environment = mkEnvironment({
+    src: args.src,
+    setup: nixStrLit`
       echo copying node_modules
       cp -r ${node_modules}/node_modules .
       chmod -R u+rwX node_modules
     `,
-  ).withDevTools([mkPackage(nodejs, "nodejs")]);
+  }).withDevTools([mkPackage(nodejs, "nodejs")]);
   return mkProject(
     {
       description: args.description,
@@ -148,8 +144,8 @@ export function mkYarnProject(args: {
     `,
     "startCommand",
   );
-  const devShell: Environment = mkEnvironment(
-    nixRaw`
+  const devShell: Environment = mkEnvironment({
+    nixExpression: nixRaw`
       let
           pkgs = ${pkgs};
           packageJson = pkgs.lib.importJSON ${nixRaw(args.src)}/package.json;
@@ -166,13 +162,8 @@ export function mkYarnProject(args: {
           `};
         }
     `,
-    nixStrLit`
-      echo copying source
-      cp -r ${nixSource(args.src)} src
-      chmod -R u+rwX src
-      cd src
-    `,
-  );
+    src: args.src,
+  });
   const startDev: Executable = devShell.shell`cd ${args.src} && ${startCommand}`;
   return mkProject(
     {

--- a/ts/testUtils.ts
+++ b/ts/testUtils.ts
@@ -30,15 +30,15 @@ const printOutput = (output: Output) => {
 };
 
 export const assertSuccess = (output: Output): Output =>
-  assertOnOutput(output, () => assertEquals(output.exitCode, 0));
+  printOutputOnFailure(output, () => assertEquals(output.exitCode, 0));
 
 export const assertStdout = (output: Output, expected: string): Output =>
-  assertOnOutput(output, () => assertEquals(output.stdout, expected));
+  printOutputOnFailure(output, () => assertEquals(output.stdout, expected));
 
 export const assertStderr = (output: Output, expected: string): Output =>
-  assertOnOutput(output, () => assertEquals(output.stderr, expected));
+  printOutputOnFailure(output, () => assertEquals(output.stderr, expected));
 
-export const assertOnOutput = (
+export const printOutputOnFailure = (
   output: Output,
   assertion: () => void,
 ): Output => {

--- a/ts/testUtils.ts
+++ b/ts/testUtils.ts
@@ -98,9 +98,10 @@ export const runExecutable = (
 
 export const runCheck = (
   check: garn.Check,
-  options: { cwd?: string } = {},
+  options: { tempDir?: string } = {},
 ): Output => {
-  const tempDir = Deno.makeTempDirSync({ prefix: "garn-test" });
+  const tempDir =
+    options.tempDir ?? Deno.makeTempDirSync({ prefix: "garn-test" });
   const nixpkgsInput = nix.nixFlakeDep("nixpkgs-repo", {
     url: "github:NixOS/nixpkgs/6fc7203e423bbf1c8f84cccf1c4818d097612566",
   });
@@ -122,10 +123,45 @@ export const runCheck = (
   Deno.writeTextFileSync(`${tempDir}/flake.nix`, flakeFile);
   return runCommand(
     new Deno.Command("nix", {
-      args: ["flake", "check", tempDir],
-      cwd: options.cwd,
+      args: ["flake", "check", "-L", tempDir],
     }),
   );
+};
+
+export const buildPackage = (
+  pkg: garn.Package,
+  options: { tempDir?: string } = {},
+): string => {
+  const tempDir =
+    options.tempDir ?? Deno.makeTempDirSync({ prefix: "garn-test" });
+  const nixpkgsInput = nix.nixFlakeDep("nixpkgs-repo", {
+    url: "github:NixOS/nixpkgs/6fc7203e423bbf1c8f84cccf1c4818d097612566",
+  });
+  const flakeFile = nix.renderFlakeFile(
+    nixAttrSet({
+      packages: nixAttrSet({
+        "x86_64-linux": nixAttrSet({
+          default: nix.nixRaw`
+                  let pkgs = import ${nixpkgsInput} {
+                        config.allowUnfree = true;
+                        system = "x86_64-linux";
+                      };
+                  in ${pkg.nixExpression}
+                `,
+        }),
+      }),
+    }),
+  );
+  Deno.writeTextFileSync(`${tempDir}/flake.nix`, flakeFile);
+  assertSuccess(
+    runCommand(
+      new Deno.Command("nix", {
+        args: ["build", "-L", tempDir],
+        cwd: tempDir,
+      }),
+    ),
+  );
+  return Deno.readLinkSync(`${tempDir}/result`);
 };
 
 export const testPkgs = {

--- a/ts/testUtils.ts
+++ b/ts/testUtils.ts
@@ -2,6 +2,7 @@ import { assertEquals } from "https://deno.land/std@0.206.0/assert/mod.ts";
 import * as garn from "./mod.ts";
 import * as nix from "./nix.ts";
 import { nixAttrSet } from "./nix.ts";
+import { mkPackage } from "./mod.ts";
 
 type Output = {
   exitCode: number;
@@ -99,4 +100,8 @@ export const runExecutable = (
       cwd: options.cwd,
     }),
   );
+};
+
+export const testPkgs = {
+  hello: mkPackage(nix.nixRaw("pkgs.hello"), "hello"),
 };

--- a/ts/testUtils.ts
+++ b/ts/testUtils.ts
@@ -98,10 +98,9 @@ export const runExecutable = (
 
 export const runCheck = (
   check: garn.Check,
-  options: { tempDir?: string } = {},
+  options: { dir?: string } = {},
 ): Output => {
-  const tempDir =
-    options.tempDir ?? Deno.makeTempDirSync({ prefix: "garn-test" });
+  const dir = options.dir ?? Deno.makeTempDirSync({ prefix: "garn-test" });
   const nixpkgsInput = nix.nixFlakeDep("nixpkgs-repo", {
     url: "github:NixOS/nixpkgs/6fc7203e423bbf1c8f84cccf1c4818d097612566",
   });
@@ -120,20 +119,19 @@ export const runCheck = (
       }),
     }),
   );
-  Deno.writeTextFileSync(`${tempDir}/flake.nix`, flakeFile);
+  Deno.writeTextFileSync(`${dir}/flake.nix`, flakeFile);
   return runCommand(
     new Deno.Command("nix", {
-      args: ["flake", "check", "-L", tempDir],
+      args: ["flake", "check", "-L", dir],
     }),
   );
 };
 
 export const buildPackage = (
   pkg: garn.Package,
-  options: { tempDir?: string } = {},
+  options: { dir?: string } = {},
 ): string => {
-  const tempDir =
-    options.tempDir ?? Deno.makeTempDirSync({ prefix: "garn-test" });
+  const dir = options.dir ?? Deno.makeTempDirSync({ prefix: "garn-test" });
   const nixpkgsInput = nix.nixFlakeDep("nixpkgs-repo", {
     url: "github:NixOS/nixpkgs/6fc7203e423bbf1c8f84cccf1c4818d097612566",
   });
@@ -152,16 +150,16 @@ export const buildPackage = (
       }),
     }),
   );
-  Deno.writeTextFileSync(`${tempDir}/flake.nix`, flakeFile);
+  Deno.writeTextFileSync(`${dir}/flake.nix`, flakeFile);
   assertSuccess(
     runCommand(
       new Deno.Command("nix", {
-        args: ["build", "-L", tempDir],
-        cwd: tempDir,
+        args: ["build", "-L", dir],
+        cwd: dir,
       }),
     ),
   );
-  return Deno.readLinkSync(`${tempDir}/result`);
+  return Deno.readLinkSync(`${dir}/result`);
 };
 
 export const testPkgs = {

--- a/website/flake.nix
+++ b/website/flake.nix
@@ -80,8 +80,9 @@
               } "
     touch \$out
     ${"
-      echo copying source
-      cp -r ${(let
+      ${"
+    echo copying source
+    cp -r ${(let
     lib = pkgs.lib;
     lastSafe = list :
       if lib.lists.length list == 0
@@ -99,8 +100,10 @@
          fileName != "flake.nix" &&
          fileName != "garn.ts";
     })} src
-      chmod -R u+rwX src
-      cd src
+    chmod -R u+rwX src
+    cd src
+  "}
+      ${"
       echo copying node_modules
       cp -r ${let
         npmlock2nix = import npmlock2nix-repo {
@@ -135,6 +138,7 @@
         }}/node_modules .
       chmod -R u+rwX node_modules
     "}
+    "}
     ${"npm run tsc"}
   ";
           "website/fmt-check" =
@@ -157,8 +161,9 @@
               } "
     touch \$out
     ${"
-      echo copying source
-      cp -r ${(let
+      ${"
+    echo copying source
+    cp -r ${(let
     lib = pkgs.lib;
     lastSafe = list :
       if lib.lists.length list == 0
@@ -176,8 +181,10 @@
          fileName != "flake.nix" &&
          fileName != "garn.ts";
     })} src
-      chmod -R u+rwX src
-      cd src
+    chmod -R u+rwX src
+    cd src
+  "}
+      ${"
       echo copying node_modules
       cp -r ${let
         npmlock2nix = import npmlock2nix-repo {
@@ -211,6 +218,7 @@
           nodejs = pkgs.nodejs-18_x;
         }}/node_modules .
       chmod -R u+rwX node_modules
+    "}
     "}
     ${"prettier '**/*.{ts,tsx}' --check"}
   ";
@@ -313,7 +321,10 @@
     } "
     #!\${pkgs.bash}/bin/bash
     mkdir \$out
-    ${""}
+    ${"
+      ${""}
+      ${""}
+    "}
     ${"
     USER_CONFIG=.config/VSCodium/User
     if test \$(uname) = \"Darwin\" ; then
@@ -341,7 +352,10 @@
     } "
     #!\${pkgs.bash}/bin/bash
     mkdir \$out
-    ${""}
+    ${"
+      ${""}
+      ${""}
+    "}
     ${"
     set -euo pipefail
     cat ${pkgs.writeTextFile {


### PR DESCRIPTION
This PR is a smaller change to `mkEnvironment`: It allows to pass in an `src` argument that will make the source files available in `Check`s and `Package`s that are created from that environment. Before this was being done manually through the `setup` parameter.

I think there's some more refactorings that we should make to `Environment`s (and at some point `Project`s), but I think this is definitely a step in the right direction.

The PR also backfills some tests for `Environment`s in typescript and adds some testing infrastructure for that.
