### PR TITLE
initialize python integration

### DIFF
--- a/examples/python/flake.lock
+++ b/examples/python/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs-repo": {
+      "locked": {
+        "lastModified": 1698376214,
+        "narHash": "sha256-8UC0cK/cT600ug+8RVc6a1sE66+U1dfsileTo65zPCg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6fc7203e423bbf1c8f84cccf1c4818d097612566",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6fc7203e423bbf1c8f84cccf1c4818d097612566",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs-repo": "nixpkgs-repo"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/examples/python/flake.nix
+++ b/examples/python/flake.nix
@@ -1,0 +1,233 @@
+{
+  inputs.nixpkgs-repo.url = "github:NixOS/nixpkgs/6fc7203e423bbf1c8f84cccf1c4818d097612566";
+  outputs = { self, nixpkgs-repo }:
+    let
+      nixpkgs = nixpkgs-repo;
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = import "${nixpkgs}" {
+            config.allowUnfree = true;
+            inherit system;
+          };
+        in
+        {
+          "someproject/package" =
+            let
+              lib = pkgs.lib;
+              python = pkgs.pythonInterpreters.python310;
+              src = (
+                let
+                  lib = pkgs.lib;
+                  lastSafe = list:
+                    if lib.lists.length list == 0
+                    then null
+                    else lib.lists.last list;
+                in
+                builtins.path
+                  {
+                    path = ./.;
+                    name = "source";
+                    filter = path: type:
+                      let
+                        fileName = lastSafe (lib.strings.splitString "/" path);
+                      in
+                      fileName != "flake.nix" &&
+                      fileName != "garn.ts";
+                  }
+              );
+              pyproject = builtins.fromTOML
+                (builtins.readFile "${src}/pyproject.toml");
+              dependencies = pyproject.project.dependencies or [ ];
+              pickPackage = dep: python.pkgs.${dep} or (throw ''
+                Package not supported or not available: ${dep}
+                Dependency not found in nixpkgs python packages
+              '');
+              toPackages = map pickPackage;
+              pythonDependencies = toPackages dependencies;
+              pythonSetupDependencies = toPackages pyproject.build-system.requires or [ "setuptools" ];
+            in
+            python.pkgs.buildPythonPackage {
+              pname = pyproject.project.name;
+              version = pyproject.project.version;
+              src = (
+                let
+                  lib = pkgs.lib;
+                  lastSafe = list:
+                    if lib.lists.length list == 0
+                    then null
+                    else lib.lists.last list;
+                in
+                builtins.path
+                  {
+                    path = ./.;
+                    name = "source";
+                    filter = path: type:
+                      let
+                        fileName = lastSafe (lib.strings.splitString "/" path);
+                      in
+                      fileName != "flake.nix" &&
+                      fileName != "garn.ts";
+                  }
+              );
+              format = "pyproject";
+              buildInputs = pythonSetupDependencies;
+              propagatedBuildInputs = pythonDependencies;
+            };
+        }
+      );
+      checks = forAllSystems (system:
+        let
+          pkgs = import "${nixpkgs}" {
+            config.allowUnfree = true;
+            inherit system;
+          };
+        in
+        { }
+      );
+      devShells = forAllSystems (system:
+        let
+          pkgs = import "${nixpkgs}" {
+            config.allowUnfree = true;
+            inherit system;
+          };
+        in
+        {
+          "someproject" =
+            let
+              lib = pkgs.lib;
+              python = pkgs.pythonInterpreters.python310;
+              src = (
+                let
+                  lib = pkgs.lib;
+                  lastSafe = list:
+                    if lib.lists.length list == 0
+                    then null
+                    else lib.lists.last list;
+                in
+                builtins.path
+                  {
+                    path = ./.;
+                    name = "source";
+                    filter = path: type:
+                      let
+                        fileName = lastSafe (lib.strings.splitString "/" path);
+                      in
+                      fileName != "flake.nix" &&
+                      fileName != "garn.ts";
+                  }
+              );
+              pyproject = builtins.fromTOML
+                (builtins.readFile "${src}/pyproject.toml");
+              dependencies = pyproject.project.dependencies or [ ];
+              pickPackage = dep: python.pkgs.${dep} or (throw ''
+                Package not supported or not available: ${dep}
+                Dependency not found in nixpkgs python packages
+              '');
+              toPackages = map pickPackage;
+              pythonDependencies = toPackages dependencies;
+              pythonSetupDependencies = toPackages pyproject.build-system.requires or [ "setuptools" ];
+              pythonWithDeps = python.withPackages (ps:
+                pythonDependencies
+                ++ pythonSetupDependencies
+                ++ [
+                  python.pkgs.pip
+                  python.pkgs.wheel
+                ]
+              );
+              shellHook = ''
+                tmp_path=$(realpath ./.pythonenv)
+                mkdir -p "$tmp_path"
+
+                repo_root=$(realpath .)
+                mkdir -p "$tmp_path/python/${python.sitePackages}"
+
+                # Install the package in editable mode
+                # This allows executing scripts from within the dev-shell using the current
+                # version of the code and its dependencies.
+                ${pythonWithDeps.interpreter} -m pip install             --quiet             --disable-pip-version-check             --no-index             --no-build-isolation             --prefix "$tmp_path/python"             --editable $repo_root
+
+                export PATH="$tmp_path/python/bin:$PATH"
+                export PYTHONPATH="$repo_root:$tmp_path/python/${pythonWithDeps.sitePackages}:"
+              '';
+            in
+            pythonWithDeps.env.overrideAttrs (old: {
+              shellHook = old.shellHook or "" + "\n" + shellHook;
+            });
+          "someproject/devShell" =
+            let
+              lib = pkgs.lib;
+              python = pkgs.pythonInterpreters.python310;
+              src = (
+                let
+                  lib = pkgs.lib;
+                  lastSafe = list:
+                    if lib.lists.length list == 0
+                    then null
+                    else lib.lists.last list;
+                in
+                builtins.path
+                  {
+                    path = ./.;
+                    name = "source";
+                    filter = path: type:
+                      let
+                        fileName = lastSafe (lib.strings.splitString "/" path);
+                      in
+                      fileName != "flake.nix" &&
+                      fileName != "garn.ts";
+                  }
+              );
+              pyproject = builtins.fromTOML
+                (builtins.readFile "${src}/pyproject.toml");
+              dependencies = pyproject.project.dependencies or [ ];
+              pickPackage = dep: python.pkgs.${dep} or (throw ''
+                Package not supported or not available: ${dep}
+                Dependency not found in nixpkgs python packages
+              '');
+              toPackages = map pickPackage;
+              pythonDependencies = toPackages dependencies;
+              pythonSetupDependencies = toPackages pyproject.build-system.requires or [ "setuptools" ];
+              pythonWithDeps = python.withPackages (ps:
+                pythonDependencies
+                ++ pythonSetupDependencies
+                ++ [
+                  python.pkgs.pip
+                  python.pkgs.wheel
+                ]
+              );
+              shellHook = ''
+                tmp_path=$(realpath ./.pythonenv)
+                mkdir -p "$tmp_path"
+
+                repo_root=$(realpath .)
+                mkdir -p "$tmp_path/python/${python.sitePackages}"
+
+                # Install the package in editable mode
+                # This allows executing scripts from within the dev-shell using the current
+                # version of the code and its dependencies.
+                ${pythonWithDeps.interpreter} -m pip install             --quiet             --disable-pip-version-check             --no-index             --no-build-isolation             --prefix "$tmp_path/python"             --editable $repo_root
+
+                export PATH="$tmp_path/python/bin:$PATH"
+                export PYTHONPATH="$repo_root:$tmp_path/python/${pythonWithDeps.sitePackages}:"
+              '';
+            in
+            pythonWithDeps.env.overrideAttrs (old: {
+              shellHook = old.shellHook or "" + "\n" + shellHook;
+            });
+        }
+      );
+      apps = forAllSystems (system:
+        let
+          pkgs = import "${nixpkgs}" {
+            config.allowUnfree = true;
+            inherit system;
+          };
+        in
+        { }
+      );
+    };
+}

--- a/examples/python/garn.ts
+++ b/examples/python/garn.ts
@@ -1,0 +1,7 @@
+import * as garn from "http://localhost:8777/mod.ts";
+import * as pkgs from "http://localhost:8777/nixpkgs.ts";
+
+export const someproject = garn.python.mkPythonProject({
+  src: ".",
+  pythonInterpreter: garn.python.interpreters.python310,
+});

--- a/examples/python/main.py
+++ b/examples/python/main.py
@@ -1,0 +1,5 @@
+def main():
+    print('Hello World!')
+
+if __name__ == '__main__':
+    main()

--- a/examples/python/pyproject.toml
+++ b/examples/python/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "someproject"
+version = "0.1.0"
+dependencies = [
+  "requests"
+]
+
+[project.scripts]
+my-script = "main:main"
+

--- a/justfile
+++ b/justfile
@@ -143,6 +143,7 @@ check-examples:
   just run-garn frontend-yarn-webpack check
   just run-garn go-http-backend check
   just run-garn monorepo check
+  just run-garn python check
 
 update-flakefiles:
   #!/usr/bin/env bash

--- a/src/Garn/CodeGen.hs
+++ b/src/Garn/CodeGen.hs
@@ -43,6 +43,7 @@ pkgSpec =
       phpPackages = {};
       python2Packages = {};
       python3Packages = {};
+      pythonInterpreters = {};
       rubyPackages = {};
       rustPackages = {};
     }

--- a/ts/internal/init.ts
+++ b/ts/internal/init.ts
@@ -1,6 +1,7 @@
 import * as go from "../go/initializers.ts";
 import * as haskell from "../haskell/initializers.ts";
 import * as javascript from "../javascript/initializers.ts";
+import * as python from "../python/initializers.ts";
 import outdent from "https://deno.land/x/outdent@v0.8.0/mod.ts";
 import { GARN_TS_LIB_VERSION } from "./version.ts";
 
@@ -14,6 +15,7 @@ const initializers = [
   ...go.initializers,
   ...haskell.initializers,
   ...javascript.initializers,
+  ...python.initializers,
 ];
 
 for (const init of initializers) {
@@ -62,6 +64,11 @@ if (initializedSections.length === 0) {
     //   description: "My node project",
     //   src: "./my-node-project",
     //   nodeVersion: "18",
+    // });
+
+    // export const myPythonProject = garn.python.mkPythonProject({
+    //   src: "./my-python-project",
+    //   pythonInterpreter: garn.python.interpreters.python310,
     // });
 
 

--- a/ts/internal/utils.ts
+++ b/ts/internal/utils.ts
@@ -1,5 +1,6 @@
 import { NixExpression, nixRaw, nixStrLit } from "../nix.ts";
 import { z } from "https://deno.land/x/zod@v3.22.4/mod.ts";
+import * as toml from "https://deno.land/std@0.109.0/encoding/toml.ts";
 
 export const nixSource = (src: string): NixExpression => nixRaw`
   (let
@@ -81,12 +82,28 @@ export const writeTextFile = (
   }
 `;
 
-type Result<T> = { data: T; error?: never } | { error: Error; data?: never };
+export type Result<T> =
+  | { data: T; error?: never }
+  | { error: Error; data?: never };
 
 export const parseJson = <T>(schema: z.Schema<T>, json: string): Result<T> => {
   let parsed: unknown;
   try {
     parsed = JSON.parse(json);
+  } catch (error) {
+    return { error };
+  }
+  const result = schema.safeParse(parsed);
+  if (!result.success) {
+    return { error: result.error };
+  }
+  return { data: result.data };
+};
+
+export const parseToml = <T>(schema: z.Schema<T>, json: string): Result<T> => {
+  let parsed: unknown;
+  try {
+    parsed = toml.parse(json);
   } catch (error) {
     return { error };
   }

--- a/ts/mod.ts
+++ b/ts/mod.ts
@@ -20,6 +20,7 @@ export {
 export * as go from "./go/mod.ts";
 export * as haskell from "./haskell/mod.ts";
 export * as javascript from "./javascript/mod.ts";
+export * as python from "./python/mod.ts";
 
 // tools
 export { processCompose } from "./process_compose.ts";

--- a/ts/python/initializers.test.ts
+++ b/ts/python/initializers.test.ts
@@ -1,0 +1,59 @@
+import {
+  assertEquals,
+  assert,
+} from "https://deno.land/std@0.201.0/assert/mod.ts";
+import outdent from "https://deno.land/x/outdent@v0.8.0/mod.ts";
+import { join } from "https://deno.land/std@0.201.0/path/mod.ts";
+import { pythonInitializer } from "./initializers.ts";
+import * as toml from "https://deno.land/std@0.109.0/encoding/toml.ts";
+
+Deno.test(
+  "Python initializer does not run when pyproject.toml is not present",
+  () => {
+    const tempDir = Deno.makeTempDirSync();
+    const result = pythonInitializer(tempDir);
+    assertEquals(result.tag, "ShouldNotRun");
+  },
+);
+
+Deno.test("Python initializer errors if pyproject.toml is unparseable", () => {
+  const tempDir = Deno.makeTempDirSync();
+  Deno.writeTextFileSync(
+    join(tempDir, "pyproject.toml"),
+    `
+      some invalid: toml
+    `,
+  );
+  const result = pythonInitializer(tempDir);
+  if (result.tag !== "UnexpectedError") {
+    throw new Error("expected an UnexpectedError");
+  }
+  assert(result.reason.startsWith("Could not parse pyproject.toml"));
+});
+
+Deno.test("Python initializer returns the code to be generated", () => {
+  const tempDir = Deno.makeTempDirSync();
+  Deno.writeTextFileSync(
+    join(tempDir, "pyproject.toml"),
+    toml.stringify({
+      project: {
+        name: "somepackage",
+        version: "0.0.0",
+        description: "just some package",
+      },
+    }),
+  );
+  const result = pythonInitializer(tempDir);
+  if (result.tag !== "ShouldRun") {
+    throw new Error("Expected initializer to run");
+  }
+  assertEquals(
+    result.makeTarget(),
+    outdent`
+      export const somepackage = garn.python.mkPythonProject({
+        src: ".",
+        pythonInterpreter: garn.python.interpreters.python310,
+      });
+    `,
+  );
+});

--- a/ts/python/initializers.ts
+++ b/ts/python/initializers.ts
@@ -1,0 +1,40 @@
+import { Initializer } from "../base.ts";
+import * as fs from "https://deno.land/std@0.201.0/fs/mod.ts";
+import outdent from "https://deno.land/x/outdent@v0.8.0/mod.ts";
+import { camelCase } from "https://deno.land/x/case@2.2.0/mod.ts";
+import { join } from "https://deno.land/std@0.201.0/path/mod.ts";
+import { parseToml } from "../internal/utils.ts";
+import { z } from "https://deno.land/x/zod@v3.22.4/mod.ts";
+import { parsePyprojectToml } from "./utils.ts";
+
+export const pythonInitializer: Initializer = (dir) => {
+  const existPyprojetToml = fs.existsSync(join(dir, "pyproject.toml"));
+  if (!existPyprojetToml) {
+    return { tag: "ShouldNotRun" };
+  }
+  const contents = Deno.readTextFileSync(join(dir, "pyproject.toml"));
+  const result = parsePyprojectToml(contents);
+  if (result.error) {
+    return {
+      tag: "UnexpectedError",
+      reason: `Could not parse pyproject.toml: ${result.error.message}`,
+    };
+  }
+  return {
+    tag: "ShouldRun",
+    imports: [],
+    makeTarget: () =>
+      [
+        outdent`
+          export const ${camelCase(
+            result.data.project.name || "npmProject",
+          )} = garn.python.mkPythonProject({
+            src: ".",
+            pythonInterpreter: garn.python.interpreters.python310,
+          })
+        `,
+      ].join("\n  ") + ";",
+  };
+};
+
+export const initializers = [pythonInitializer];

--- a/ts/python/mod.test.ts
+++ b/ts/python/mod.test.ts
@@ -1,47 +1,57 @@
-import { describe, it } from "https://deno.land/std@0.206.0/testing/bdd.ts";
+import {
+  beforeEach,
+  describe,
+  it,
+} from "https://deno.land/std@0.206.0/testing/bdd.ts";
 import * as garn from "./mod.ts";
-import { buildPackage, runCommand } from "../testUtils.ts";
+import { buildPackage, runCommand, runInDevShell } from "../testUtils.ts";
 import { assert } from "https://deno.land/std@0.206.0/assert/mod.ts";
 import { existsSync } from "https://deno.land/std@0.201.0/fs/exists.ts";
 import { assertStringIncludes } from "https://deno.land/std@0.206.0/assert/assert_string_includes.ts";
 import outdent from "https://deno.land/x/outdent@v0.8.0/mod.ts";
+import * as pythonInterpreters from "../internal/nixpkgs/pythonInterpreters/mod.ts";
+
+const pyprojectToml = outdent`
+  [build-system]
+  requires = ["setuptools"]
+  build-backend = "setuptools.build_meta"
+
+  [project]
+  name = "my_package"
+  version = "0.0.0"
+
+  dependencies = [
+    "requests"
+  ]
+
+  [project.scripts]
+  my-script = "my_package:main"
+`;
+
+const myPackagePy = outdent`
+  import requests
+
+  def main():
+      print(f"using requests version {requests.__version__}")
+      print("Hello, world!")
+
+  if __name__ == "__main__":
+      main()
+`;
 
 describe("mkPythonProject", () => {
-  it("allows building a python project and running scripts from it", () => {
-    const tempDir = Deno.makeTempDirSync({
-      prefix: "garn-mkPythonProject-test",
-    });
-    const pyprojectToml = outdent`
-      [build-system]
-      requires = ["setuptools"]
-      build-backend = "setuptools.build_meta"
-
-      [project]
-      name = "my_package"
-      version = "0.0.0"
-
-      dependencies = [
-        "requests"
-      ]
-
-      [project.scripts]
-      my-script = "my_package:main"
-    `;
-    const myPackagePy = outdent`
-      import requests
-
-      def main():
-          print(f"using requests version {requests.__version__}")
-          print("Hello, world!")
-
-      if __name__ == "__main__":
-          main()
-    `;
+  let tempDir: string;
+  beforeEach(() => {
+    tempDir = Deno.makeTempDirSync({ prefix: "garn-mkPythonProject-test" });
     Deno.writeTextFileSync(`${tempDir}/pyproject.toml`, pyprojectToml);
     Deno.writeTextFileSync(`${tempDir}/my_package.py`, myPackagePy);
+  });
+
+  it("allows building a python project and running scripts from it", () => {
     const project = garn.mkPythonProjectSimple({
       src: "./.",
       description: "A python project",
+      pythonInterpreter: pythonInterpreters.python310,
     });
     const output = buildPackage(project.package, { dir: tempDir });
     assert(existsSync(`${output}/bin/my-script`));
@@ -50,5 +60,17 @@ describe("mkPythonProject", () => {
       new Deno.Command(`${output}/bin/my-script`, {}),
     );
     assertStringIncludes(myScriptOutput.stdout, "Hello, world!");
+  });
+
+  it("generates a working devShell containing the python deps", () => {
+    const project = garn.mkPythonProjectSimple({
+      src: "./.",
+      description: "A python project",
+      pythonInterpreter: pythonInterpreters.python310,
+    });
+    runInDevShell(project.devShell, {
+      dir: tempDir,
+      cmd: "python -c 'import requests; print(requests.__version__)'",
+    });
   });
 });

--- a/ts/python/mod.test.ts
+++ b/ts/python/mod.test.ts
@@ -1,0 +1,54 @@
+import { describe, it } from "https://deno.land/std@0.206.0/testing/bdd.ts";
+import * as garn from "./mod.ts";
+import { buildPackage, runCommand } from "../testUtils.ts";
+import { assert } from "https://deno.land/std@0.206.0/assert/mod.ts";
+import { existsSync } from "https://deno.land/std@0.201.0/fs/exists.ts";
+import { assertStringIncludes } from "https://deno.land/std@0.206.0/assert/assert_string_includes.ts";
+import outdent from "https://deno.land/x/outdent@v0.8.0/mod.ts";
+
+describe("mkPythonProject", () => {
+  it("allows building a python project and running scripts from it", () => {
+    const tempDir = Deno.makeTempDirSync({
+      prefix: "garn-mkPythonProject-test",
+    });
+    const pyprojectToml = outdent`
+      [build-system]
+      requires = ["setuptools"]
+      build-backend = "setuptools.build_meta"
+
+      [project]
+      name = "my_package"
+      version = "0.0.0"
+
+      dependencies = [
+        "requests"
+      ]
+
+      [project.scripts]
+      my-script = "my_package:main"
+    `;
+    const myPackagePy = outdent`
+      import requests
+
+      def main():
+          print(f"using requests version {requests.__version__}")
+          print("Hello, world!")
+
+      if __name__ == "__main__":
+          main()
+    `;
+    Deno.writeTextFileSync(`${tempDir}/pyproject.toml`, pyprojectToml);
+    Deno.writeTextFileSync(`${tempDir}/my_package.py`, myPackagePy);
+    const project = garn.mkPythonProjectSimple({
+      src: "./.",
+      description: "A python project",
+    });
+    const output = buildPackage(project.package, { dir: tempDir });
+    assert(existsSync(`${output}/bin/my-script`));
+    // run the script
+    const myScriptOutput = runCommand(
+      new Deno.Command(`${output}/bin/my-script`, {}),
+    );
+    assertStringIncludes(myScriptOutput.stdout, "Hello, world!");
+  });
+});

--- a/ts/python/mod.ts
+++ b/ts/python/mod.ts
@@ -3,7 +3,6 @@ import { mkPackage, Package } from "../package.ts";
 import { mkProject, Project } from "../project.ts";
 import { nixSource } from "../internal/utils.ts";
 import { nixRaw } from "../nix.ts";
-
 export { plugin as vite } from "../javascript/vite.ts";
 
 /**
@@ -12,43 +11,89 @@ export { plugin as vite } from "../javascript/vite.ts";
 export function mkPythonProjectSimple(args: {
   description: string;
   src: string;
+  pythonInterpreter: Package;
 }): Project & {
   package: Package;
-  // devShell: Environment;
+  devShell: Environment;
 } {
+  const python = args.pythonInterpreter.nixExpression;
+  const pythonDependencies = nixRaw`
+    let
+      python = ${python};
+      src = ${nixSource(args.src)};
+      pyproject = builtins.fromTOML
+        (builtins.readFile "\${src}/pyproject.toml");
+      dependencies = pyproject.project.dependencies;
+      toPackages = map (dep: python.pkgs.\${dep});
+    in
+      toPackages dependencies
+  `;
   const pkg: Package = mkPackage(
     nixRaw`
       let
         lib = pkgs.lib;
-        python = pkgs.python3;
+        python = ${python};
         src = ${nixSource(args.src)};
         pyproject = builtins.fromTOML
           (builtins.readFile "\${src}/pyproject.toml");
         dependencies = pyproject.project.dependencies;
         toPackages = map (dep: python.pkgs.\${dep});
       in
-        pkgs.python3.pkgs.buildPythonPackage {
+        python.pkgs.buildPythonPackage {
           pname = pyproject.project.name;
           version = pyproject.project.version;
           src = ${nixSource(args.src)};
           format = "pyproject";
           buildInputs = toPackages pyproject.build-system.requires;
-          propagatedBuildInputs = toPackages dependencies;
+          propagatedBuildInputs = ${pythonDependencies};
         }
     `,
     "package",
   );
   const devShell: Environment = mkEnvironment({
-    nixExpression: nixRaw`echo TODO`,
+    nixExpression: nixRaw`
+      let
+        python = ${python};
+        pythonDependencies = ${pythonDependencies};
+        pythonWithDeps = python.withPackages (ps:
+          pythonDependencies
+          ++ [python.pkgs.pip]
+        );
+        shellHook = ''
+          tmp_path=$(realpath ./.pythonenv)
+          mkdir -p "$tmp_path"
+
+          repo_root=$(realpath .)
+          mkdir -p "$tmp_path/python/\${python.sitePackages}"
+
+          # Install the package in editable mode
+          # This allows executing scripts from within the dev-shell using the current
+          # version of the code and its dependencies.
+          \${pythonWithDeps.interpreter} -m pip install \
+            --quiet \
+            --disable-pip-version-check \
+            --no-index \
+            --no-build-isolation \
+            --prefix "$tmp_path/python" \
+            --editable $repo_root
+
+          export PATH="$tmp_path/python/bin:$PATH"
+          export PYTHONPATH="$repo_root:$tmp_path/python/\${pythonWithDeps.sitePackages}:"
+        '';
+      in
+        pythonWithDeps.env.overrideAttrs (old: {
+          shellHook = old.shellHook or "" + "\\n" + shellHook;
+        })
+    `,
   });
   return mkProject(
     {
       description: args.description,
-      // defaultEnvironment: devShell,
+      defaultEnvironment: devShell,
     },
     {
       package: pkg,
-      // devShell,
+      devShell,
     },
   );
 }

--- a/ts/python/mod.ts
+++ b/ts/python/mod.ts
@@ -10,12 +10,19 @@ export { plugin as vite } from "../javascript/vite.ts";
 export const interpreters = pythonInterpreters;
 
 /**
- * Creates a pyproject based python garn Project.
+ * Creates a pyproject.toml based python project.
+ *
+ * This will create a Project with
+ *  - a `pkg` key that builds the entire python project;
+ *  - a default shell that provides all python dependencies as well as all scripts
+ *    defined via pyproject.toml
+ *
+ * Information like name, version, description are retrieved from the pyproject.toml file.
+ *
+ * @param src - The source directory
+ * @param pythonInterpreter - The python interpreter to use. Pick one from garn.python.interpreters
  */
 export function mkPythonProject(args: {
-  // fields like name, version, description are read from pyproject.toml
-  // We want to encourage using the upstream fields as much as possible,
-  //   as this benefits portability.
   src: string;
   pythonInterpreter: Package;
 }): Project & {

--- a/ts/python/mod.ts
+++ b/ts/python/mod.ts
@@ -1,0 +1,54 @@
+import { Environment, mkEnvironment } from "../environment.ts";
+import { mkPackage, Package } from "../package.ts";
+import { mkProject, Project } from "../project.ts";
+import { nixSource } from "../internal/utils.ts";
+import { nixRaw } from "../nix.ts";
+
+export { plugin as vite } from "../javascript/vite.ts";
+
+/**
+ * Creates a pyproject based python garn Project.
+ */
+export function mkPythonProjectSimple(args: {
+  description: string;
+  src: string;
+}): Project & {
+  package: Package;
+  // devShell: Environment;
+} {
+  const pkg: Package = mkPackage(
+    nixRaw`
+      let
+        lib = pkgs.lib;
+        python = pkgs.python3;
+        src = ${nixSource(args.src)};
+        pyproject = builtins.fromTOML
+          (builtins.readFile "\${src}/pyproject.toml");
+        dependencies = pyproject.project.dependencies;
+        toPackages = map (dep: python.pkgs.\${dep});
+      in
+        pkgs.python3.pkgs.buildPythonPackage {
+          pname = pyproject.project.name;
+          version = pyproject.project.version;
+          src = ${nixSource(args.src)};
+          format = "pyproject";
+          buildInputs = toPackages pyproject.build-system.requires;
+          propagatedBuildInputs = toPackages dependencies;
+        }
+    `,
+    "package",
+  );
+  const devShell: Environment = mkEnvironment({
+    nixExpression: nixRaw`echo TODO`,
+  });
+  return mkProject(
+    {
+      description: args.description,
+      // defaultEnvironment: devShell,
+    },
+    {
+      package: pkg,
+      // devShell,
+    },
+  );
+}

--- a/ts/python/utils.ts
+++ b/ts/python/utils.ts
@@ -1,0 +1,19 @@
+import { z } from "https://deno.land/x/zod@v3.22.4/mod.ts";
+import { Result, parseToml } from "../internal/utils.ts";
+
+const pyprojectTomlSchema = z.object({
+  project: z.object({
+    name: z.string(),
+    version: z.string(),
+    description: z.string().optional(),
+    scripts: z.record(z.string()).optional(),
+    dependencies: z.array(z.string()).optional(),
+  }),
+});
+
+export const parsePyprojectToml = (
+  contents: string,
+): Result<(typeof pyprojectTomlSchema)["_output"]> => {
+  const result = parseToml(pyprojectTomlSchema, contents);
+  return result;
+};

--- a/ts/testUtils.ts
+++ b/ts/testUtils.ts
@@ -70,7 +70,7 @@ export const nixpkgsInput = nix.nixFlakeDep("nixpkgs-repo", {
   url: "github:NixOS/nixpkgs/6fc7203e423bbf1c8f84cccf1c4818d097612566",
 });
 
-const pkgs = nix.nixRaw`
+export const pkgs = nix.nixRaw`
   import ${nixpkgsInput} {
     config.allowUnfree = true;
     system = "x86_64-linux";


### PR DESCRIPTION
based on https://github.com/garnix-io/garn/pull/425

This initializes basic pyprojet.toml python support.

It is simplified and only supports dependencies which are in nixpkgs. It raises an error in case a requested dependency is not found in nixpkgs. 

At a later stage this should probably make use of some python2nix approach for getting the correct versions of dependencies.
