### PR TITLE
Fix double-dash subcommand parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Tweak the API for creating `Environment`s, making it easier to create
   `Environment`s that have a source directory
 
+- Fix needing to use `--` twice in `garn run` in order to pass arguments to
+  executables.
+
 ## v0.0.16
 
 - Allow to build packages that are nested within projects with `garn build projectName.packageName`.

--- a/src/Garn/Optparse.hs
+++ b/src/Garn/Optparse.hs
@@ -21,7 +21,7 @@ import qualified Text.PrettyPrint.ANSI.Leijen as PP
 
 getOpts :: OptionType -> IO Options
 getOpts oType =
-  customExecParser (prefs $ showHelpOnError <> showHelpOnEmpty) opts
+  customExecParser (prefs $ subparserInline <> showHelpOnError <> showHelpOnEmpty) opts
   where
     unavailable :: OA.Doc
     unavailable =

--- a/test/spec/RunSpec.hs
+++ b/test/spec/RunSpec.hs
@@ -141,6 +141,19 @@ spec =
           stdout output `shouldBe` "foo bar,baz,"
           exitCode output `shouldBe` ExitSuccess
 
+        it "allows specifying options to the executable with --" $ \onTestFailureLog -> do
+          writeFile
+            "garn.ts"
+            [i|
+              import * as garn from "#{repoDir}/ts/mod.ts"
+
+              export const main = garn.shell('printf "%s,%s,%s"');
+            |]
+          output <- runGarn ["run", "main", "--", "--bar", "--baz"] "" repoDir Nothing
+          onTestFailureLog output
+          stdout output `shouldBe` "--bar,--baz,"
+          exitCode output `shouldBe` ExitSuccess
+
         it "doesn’t format other Nix files" $ \onTestFailureLog -> do
           let unformattedNix =
                 [i|


### PR DESCRIPTION
Previously you had to pass `--` *twice* in order to get it to an underlying executable. This PR fixes that by inlining subparsers.

A further advantage of this change is that you can now mix global and local (subcommand-specific) options. It seems like the old behavior was only there for backwards-compatibility reasons (see https://github.com/pcapriotti/optparse-applicative/issues/433#issuecomment-892526113).