### PR TITLE
Run args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
 - Fix needing to use `--` twice in `garn run` in order to pass arguments to
   executables.
 
+- Require explicit passing of arguments via `"$@"` in `shell`. This allows users
+  to have much more control over the behavior of their shell commands, and
+  in particular allows multiline scripts to handle arguments (in exactly the
+  same way as normal bash scripts).
+
 ## v0.0.16
 
 - Allow to build packages that are nested within projects with `garn build projectName.packageName`.

--- a/examples/frontend-yarn-webpack/flake.nix
+++ b/examples/frontend-yarn-webpack/flake.nix
@@ -182,7 +182,7 @@
         #!${pkgs.bash}/bin/bash
         export PATH=$(cat ${buildPath}):$PATH
         ${dev.shellHook}
-        ${shell} "$@"
+        ${shell}
       ''}";
           };
           "frontend/startDev" = {
@@ -236,7 +236,7 @@
         #!${pkgs.bash}/bin/bash
         export PATH=$(cat ${buildPath}):$PATH
         ${dev.shellHook}
-        ${shell} "$@"
+        ${shell}
       ''}";
           };
         }

--- a/examples/go-http-backend/flake.nix
+++ b/examples/go-http-backend/flake.nix
@@ -188,7 +188,7 @@
         #!${pkgs.bash}/bin/bash
         export PATH=$(cat ${buildPath}):$PATH
         ${dev.shellHook}
-        ${shell} "$@"
+        ${shell}
       ''}";
           };
           "server/dev" = {
@@ -247,7 +247,7 @@
         #!${pkgs.bash}/bin/bash
         export PATH=$(cat ${buildPath}):$PATH
         ${dev.shellHook}
-        ${shell} "$@"
+        ${shell}
       ''}";
           };
         }

--- a/examples/npm-project/flake.nix
+++ b/examples/npm-project/flake.nix
@@ -256,7 +256,7 @@
         #!${pkgs.bash}/bin/bash
         export PATH=$(cat ${buildPath}):$PATH
         ${dev.shellHook}
-        ${shell} "$@"
+        ${shell}
       ''}";
           };
         }

--- a/examples/vite-frontend/flake.nix
+++ b/examples/vite-frontend/flake.nix
@@ -253,7 +253,7 @@
         #!${pkgs.bash}/bin/bash
         export PATH=$(cat ${buildPath}):$PATH
         ${dev.shellHook}
-        ${shell} "$@"
+        ${shell}
       ''}";
           };
           "frontend/preview" = {
@@ -307,7 +307,7 @@
         #!${pkgs.bash}/bin/bash
         export PATH=$(cat ${buildPath}):$PATH
         ${dev.shellHook}
-        ${shell} "$@"
+        ${shell}
       ''}";
           };
         }

--- a/test/spec/RunSpec.hs
+++ b/test/spec/RunSpec.hs
@@ -134,7 +134,7 @@ spec =
             [i|
               import * as garn from "#{repoDir}/ts/mod.ts"
 
-              export const main = garn.shell('printf "%s,%s,%s"');
+              export const main = garn.shell('printf "%s,%s,%s" "$@"');
             |]
           output <- runGarn ["run", "main", "foo bar", "baz"] "" repoDir Nothing
           onTestFailureLog output
@@ -147,7 +147,7 @@ spec =
             [i|
               import * as garn from "#{repoDir}/ts/mod.ts"
 
-              export const main = garn.shell('printf "%s,%s,%s"');
+              export const main = garn.shell('printf "%s,%s,%s" "$@"');
             |]
           output <- runGarn ["run", "main", "--", "--bar", "--baz"] "" repoDir Nothing
           onTestFailureLog output

--- a/ts/edit.ts
+++ b/ts/edit.ts
@@ -108,7 +108,7 @@ export const editGarnConfig: garn.Executable = (() => {
     export XDG_CONFIG_HOME=$TEMP_DIR/.config
     export XDG_CACHE_HOME=$TEMP_DIR/.cache
 
-    ${vscodium}/bin/codium --new-window --disable-workspace-trust ./garn.ts --wait
+    ${vscodium}/bin/codium --new-window --disable-workspace-trust ./garn.ts --wait "$@"
 
     rm -rf $TEMP_DIR
   `;

--- a/ts/environment.ts
+++ b/ts/environment.ts
@@ -31,6 +31,8 @@ export type Environment = {
   withDevTools(devTools: Array<Package>): Environment;
   /**
    * Creates a new shell script `Executable`, run inside this `Environment`
+   *
+   * In order to allow arguments to your script, use `"$@"` where appropriate.
    */
   shell(script: string): Executable;
   shell(

--- a/ts/executable.ts
+++ b/ts/executable.ts
@@ -85,7 +85,7 @@ export function mkShellExecutable(
         #!\${pkgs.bash}/bin/bash
         export PATH=$(cat \${buildPath}):$PATH
         \${dev.shellHook}
-        \${shell} "$@"
+        \${shell}
       ''
     `;
   return mkExecutable(

--- a/ts/process_compose.ts
+++ b/ts/process_compose.ts
@@ -35,7 +35,7 @@ export function processCompose(
     "process-compose config",
   );
 
-  const result = emptyEnvironment.shell`${nixRaw`pkgs.process-compose`}/bin/process-compose up -f ${configYml}`;
+  const result = emptyEnvironment.shell`${nixRaw`pkgs.process-compose`}/bin/process-compose up -f ${configYml} "$@"`;
   result.description = `processCompose(${Object.keys(executables).join(", ")})`;
   return result;
 }

--- a/website/src/docs/concepts.mdx
+++ b/website/src/docs/concepts.mdx
@@ -89,6 +89,19 @@ export const hello =
 
 You can run `Executable`s with `garn run`.
 
+If you would like `garn run` to pass arguments to your executable, use `"$@"`
+where you'd like to receive them. For examples
+
+```typescript
+import * as garn from "https://garn.io/ts/v0.0.16/mod.ts";
+
+export const hello =
+  garn.emptyEnvironment.shell('printf "My first two arguments were %s and %s" "$@"');
+```
+
+This works exactly like bash-script arguments, so it helps to know the
+differences between `"$@"`, `$@`, and `$*`.
+
 ## Packages
 
 (See also the [API docs](https://doc.deno.land/https://garn.io/ts/v0.0.16/mod.ts/~/Package).)


### PR DESCRIPTION
 Explicit shell/run arguments
    
 Previously we just tacked on $@ to the end of the shell script. But often this is completely the wrong place for it, and for basically  anything that is a proper shell script (e.g. editGarnConfig) rather than single command, makes it impossible to correctly pass arguments down.
    
 This PR changes behavior so that you have to explicitly use $@/$*. This is exactly like any bash script, so I don't think it should be too confusing.

Stacked on #437 