### PR TITLE
Add `addToSetup` and helpers to `Environment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 - Add `garn.callFlake` helper to allow importing flake files by local path.
 - Add `garn.importFlake` helper to allow importing flake files by url, e.g. from GitHub.
 
-- Add `Environment.addToSetup` and `Environment.addToSandboxSetup`, making setups for `Environment`s more flexible.
-- Remove `sandboxSetup` parameter from `mkEnvironment`, use `addtoSandboxSetup` instead.
+- Remove `sandboxSetup` parameter from `mkEnvironment`, add lower-level
+  `addToSetup` helper function to use instead.
 
 ## v0.0.18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Add `garn.callFlake` helper to allow importing flake files by local path.
 - Add `garn.importFlake` helper to allow importing flake files by url, e.g. from GitHub.
 
+- Add `Environment.addToSetup` and `Environment.addToSandboxSetup`, making setups for `Environment`s more flexible.
+- Remove `sandboxSetup` parameter from `mkEnvironment`, use `addtoSandboxSetup` instead.
+
 ## v0.0.18
 
 - Allow entering top-level `Environment`s with `garn enter`.

--- a/examples/frontend-create-react-app/flake.nix
+++ b/examples/frontend-create-react-app/flake.nix
@@ -64,9 +64,8 @@
                 buildInputs = dev.buildInputs ++ dev.nativeBuildInputs;
               } "${"mkdir -p \$out"}
 ${"
-      ${"
-    echo copying source
-    cp -r ${(let
+                echo copying source
+                cp -r ${(let
     lib = pkgs.lib;
     lastSafe = list :
       if lib.lists.length list == 0
@@ -84,11 +83,11 @@ ${"
          fileName != "flake.nix" &&
          fileName != "garn.ts";
     })}/. .
-    chmod -R u+rwX .
-  "}
-      ${"
-      echo copying node_modules
-      cp -r ${let
+                chmod -R u+rwX .
+              "}
+${"
+        echo copying node_modules
+        cp -r ${let
         npmlock2nix = import npmlock2nix-repo {
           inherit pkgs;
         };
@@ -119,11 +118,9 @@ ${"
     });
           nodejs = pkgs.nodejs-18_x;
         }}/node_modules .
-      chmod -R u+rwX node_modules
-    "}
-    "}
-${"npm run build && mv build/* \$out"}
-";
+        chmod -R u+rwX node_modules
+      "}
+${"npm run build && mv build/* \$out"}";
         }
       );
       checks = forAllSystems (system:
@@ -168,7 +165,7 @@ ${"npm run build && mv build/* \$out"}
             ++
             [(pkgs.nodejs-18_x)];
         });
-        shell = "npm install && npm start";
+        shell = "${"npm install && npm start"}";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";

--- a/examples/frontend-yarn-webpack/flake.nix
+++ b/examples/frontend-yarn-webpack/flake.nix
@@ -173,7 +173,7 @@
             export NODE_PATH=${nodeModulesPath}:\$NODE_PATH
           ";
         };
-        shell = "cd ${"."} && ${"yarn start"}";
+        shell = "${"cd ${"."} && ${"yarn start"}"}";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";
@@ -227,7 +227,7 @@
             export NODE_PATH=${nodeModulesPath}:\$NODE_PATH
           ";
         };
-        shell = "cd ${"."} && ${"yarn start"}";
+        shell = "${"cd ${"."} && ${"yarn start"}"}";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";

--- a/examples/go-http-backend/flake.nix
+++ b/examples/go-http-backend/flake.nix
@@ -179,7 +179,7 @@
             ++
             [(pkgs.gopls)];
         });
-        shell = "go run ./scripts/migrate.go";
+        shell = "${"go run ./scripts/migrate.go"}";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";
@@ -238,7 +238,7 @@
             ++
             [(pkgs.gopls)];
         });
-        shell = "go run ./main.go";
+        shell = "${"go run ./main.go"}";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";

--- a/examples/haskell/flake.nix
+++ b/examples/haskell/flake.nix
@@ -113,9 +113,8 @@
                 buildInputs = dev.buildInputs ++ dev.nativeBuildInputs;
               } "${"mkdir -p \$out"}
 ${"
-      ${"
-    echo copying source
-    cp -r ${(let
+                echo copying source
+                cp -r ${(let
     lib = pkgs.lib;
     lastSafe = list :
       if lib.lists.length list == 0
@@ -133,12 +132,9 @@ ${"
          fileName != "flake.nix" &&
          fileName != "garn.ts";
     })}/. .
-    chmod -R u+rwX .
-  "}
-      ${""}
-    "}
-${"hlint *.hs"}
-";
+                chmod -R u+rwX .
+              "}
+${"hlint *.hs"}";
         }
       );
       devShells = forAllSystems (system:
@@ -243,7 +239,7 @@ ${"hlint *.hs"}
             then expr.env
             else pkgs.mkShell { inputsFrom = [ expr ]; }
           );
-        shell = "${let
+        shell = "${"${let
       haskell = pkgs.haskell.packages.ghc94.override {
         overrides = final: prev:
           {  }
@@ -269,7 +265,7 @@ ${"hlint *.hs"}
          fileName != "flake.nix" &&
          fileName != "garn.ts";
     })
-        {}}/bin/${"hello"}";
+        {}}/bin/${"hello"}"}";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";

--- a/examples/monorepo/flake.nix
+++ b/examples/monorepo/flake.nix
@@ -295,7 +295,7 @@
             ++
             [(pkgs.gopls)];
         });
-        shell = "cd backend && go run ./main.go";
+        shell = "${"cd backend && go run ./main.go"}";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";
@@ -342,7 +342,7 @@
             then expr.env
             else pkgs.mkShell { inputsFrom = [ expr ]; }
           );
-        shell = "${let
+        shell = "${"${let
       haskell = pkgs.haskell.packages.ghc94.override {
         overrides = final: prev:
           {  }
@@ -368,7 +368,7 @@
          fileName != "flake.nix" &&
          fileName != "garn.ts";
     })
-        {}}/bin/${"hello"}";
+        {}}/bin/${"hello"}"}";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";
@@ -389,7 +389,7 @@
             ++
             [(pkgs.nodejs-18_x)];
         });
-        shell = "cd frontend-npm && npm install && npm start";
+        shell = "${"cd frontend-npm && npm install && npm start"}";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";
@@ -405,7 +405,7 @@
             "type" = "app";
             "program" = "${let
         dev = pkgs.mkShell {};
-        shell = "${pkgs.process-compose}/bin/process-compose up -f ${pkgs.writeText "process-compose.yml" (builtins.toJSON { "version" = "0.5"; "processes" = { "backend" = { "command" = "${let
+        shell = "${"${pkgs.process-compose}/bin/process-compose up -f ${pkgs.writeText "process-compose.yml" (builtins.toJSON { "version" = "0.5"; "processes" = { "backend" = { "command" = "${let
         dev = (let expr = let
         gomod2nix = gomod2nix-repo.legacyPackages.${system};
         gomod2nix-toml = pkgs.writeText "gomod2nix-toml" "schema = 3
@@ -450,7 +450,7 @@
             ++
             [(pkgs.gopls)];
         });
-        shell = "cd backend && go run ./main.go";
+        shell = "${"cd backend && go run ./main.go"}";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";
@@ -493,7 +493,7 @@
             then expr.env
             else pkgs.mkShell { inputsFrom = [ expr ]; }
           );
-        shell = "${let
+        shell = "${"${let
       haskell = pkgs.haskell.packages.ghc94.override {
         overrides = final: prev:
           {  }
@@ -519,7 +519,7 @@
          fileName != "flake.nix" &&
          fileName != "garn.ts";
     })
-        {}}/bin/${"hello"}";
+        {}}/bin/${"hello"}"}";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";
@@ -536,7 +536,7 @@
             ++
             [(pkgs.nodejs-18_x)];
         });
-        shell = "cd frontend-npm && npm install && npm start";
+        shell = "${"cd frontend-npm && npm install && npm start"}";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";
@@ -546,7 +546,7 @@
         export PATH=$(cat ${buildPath}):$PATH
         ${dev.shellHook}
         ${shell} "$@"
-      ''}"; "environment" = []; }; }; })}";
+      ''}"; "environment" = []; }; }; })}"}";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";

--- a/examples/npm-project/flake.nix
+++ b/examples/npm-project/flake.nix
@@ -74,9 +74,8 @@
                 buildInputs = dev.buildInputs ++ dev.nativeBuildInputs;
               } "${"mkdir -p \$out"}
 ${"
-      ${"
-    echo copying source
-    cp -r ${(let
+                echo copying source
+                cp -r ${(let
     lib = pkgs.lib;
     lastSafe = list :
       if lib.lists.length list == 0
@@ -94,11 +93,11 @@ ${"
          fileName != "flake.nix" &&
          fileName != "garn.ts";
     })}/. .
-    chmod -R u+rwX .
-  "}
-      ${"
-      echo copying node_modules
-      cp -r ${let
+                chmod -R u+rwX .
+              "}
+${"
+        echo copying node_modules
+        cp -r ${let
         npmlock2nix = import npmlock2nix-repo {
           inherit pkgs;
         };
@@ -129,11 +128,9 @@ ${"
     });
           nodejs = pkgs.nodejs-18_x;
         }}/node_modules .
-      chmod -R u+rwX node_modules
-    "}
-    "}
-${"npm run test"}
-";
+        chmod -R u+rwX node_modules
+      "}
+${"npm run test"}";
           "project/tsc" =
             let
               dev = (pkgs.mkShell { }).overrideAttrs (finalAttrs: previousAttrs: {
@@ -148,9 +145,8 @@ ${"npm run test"}
                 buildInputs = dev.buildInputs ++ dev.nativeBuildInputs;
               } "${"mkdir -p \$out"}
 ${"
-      ${"
-    echo copying source
-    cp -r ${(let
+                echo copying source
+                cp -r ${(let
     lib = pkgs.lib;
     lastSafe = list :
       if lib.lists.length list == 0
@@ -168,11 +164,11 @@ ${"
          fileName != "flake.nix" &&
          fileName != "garn.ts";
     })}/. .
-    chmod -R u+rwX .
-  "}
-      ${"
-      echo copying node_modules
-      cp -r ${let
+                chmod -R u+rwX .
+              "}
+${"
+        echo copying node_modules
+        cp -r ${let
         npmlock2nix = import npmlock2nix-repo {
           inherit pkgs;
         };
@@ -203,11 +199,9 @@ ${"
     });
           nodejs = pkgs.nodejs-18_x;
         }}/node_modules .
-      chmod -R u+rwX node_modules
-    "}
-    "}
-${"npm run tsc"}
-";
+        chmod -R u+rwX node_modules
+      "}
+${"npm run tsc"}";
         }
       );
       devShells = forAllSystems (system:
@@ -243,7 +237,7 @@ ${"npm run tsc"}
             ++
             [(pkgs.nodejs-18_x)];
         });
-        shell = "npm install ; npm run run";
+        shell = "${"npm install ; npm run run"}";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";

--- a/examples/vite-frontend/flake.nix
+++ b/examples/vite-frontend/flake.nix
@@ -64,9 +64,8 @@
                 buildInputs = dev.buildInputs ++ dev.nativeBuildInputs;
               } "${"mkdir -p \$out"}
 ${"
-      ${"
-    echo copying source
-    cp -r ${(let
+                echo copying source
+                cp -r ${(let
     lib = pkgs.lib;
     lastSafe = list :
       if lib.lists.length list == 0
@@ -84,11 +83,11 @@ ${"
          fileName != "flake.nix" &&
          fileName != "garn.ts";
     })}/. .
-    chmod -R u+rwX .
-  "}
-      ${"
-      echo copying node_modules
-      cp -r ${let
+                chmod -R u+rwX .
+              "}
+${"
+        echo copying node_modules
+        cp -r ${let
         npmlock2nix = import npmlock2nix-repo {
           inherit pkgs;
         };
@@ -119,9 +118,8 @@ ${"
     });
           nodejs = pkgs.nodejs-18_x;
         }}/node_modules .
-      chmod -R u+rwX node_modules
-    "}
-    "}
+        chmod -R u+rwX node_modules
+      "}
 ${"
       set -eu
 
@@ -162,8 +160,7 @@ ${"
         exit 1
       fi
       vite build --outDir \$out
-    "}
-";
+    "}";
         }
       );
       checks = forAllSystems (system:
@@ -208,7 +205,7 @@ ${"
             ++
             [(pkgs.nodejs-18_x)];
         });
-        shell = "
+        shell = "${"
       export PATH=${let
         npmlock2nix = import npmlock2nix-repo {
           inherit pkgs;
@@ -241,7 +238,7 @@ ${"
           nodejs = pkgs.nodejs-18_x;
         }}/bin:\$PATH
       vite
-    ";
+    "}";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";
@@ -262,7 +259,7 @@ ${"
             ++
             [(pkgs.nodejs-18_x)];
         });
-        shell = "
+        shell = "${"
       export PATH=${let
         npmlock2nix = import npmlock2nix-repo {
           inherit pkgs;
@@ -295,7 +292,7 @@ ${"
           nodejs = pkgs.nodejs-18_x;
         }}/bin:\$PATH
       vite preview
-    ";
+    "}";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";

--- a/test/spec/BuildSpec.hs
+++ b/test/spec/BuildSpec.hs
@@ -96,7 +96,7 @@ spec = do
             import { addToSetup } from "#{repoDir}/ts/environment.ts"
 
             const env = addToSetup(
-              "sandbox",
+              "sandboxed",
               garn.mkEnvironment(),
               garn.nix.nixStrLit`
                 mkdir dist
@@ -165,7 +165,7 @@ spec = do
               { description: "" },
               {
                 package: addToSetup(
-                    "sandbox",
+                    "sandboxed",
                     garn.mkEnvironment(),
                     nix.nixStrLit`SETUP_VAR="hello from setup"`,
                   ).build("echo $SETUP_VAR > $out/build-artifact"),

--- a/test/spec/BuildSpec.hs
+++ b/test/spec/BuildSpec.hs
@@ -104,10 +104,10 @@ spec = do
                 defaultEnvironment: env,
               }, {})
                 .addPackage("build", "mv dist/build-artifact $out/build-artifact");
-            |]
-          output <- runGarn ["build", "project"]
-          readFile "result/build-artifact" `shouldReturn` "build-content\n"
-          exitCode output `shouldBe` ExitSuccess
+          |]
+        output <- runGarn ["build", "project"]
+        readFile "result/build-artifact" `shouldReturn` "build-content\n"
+        exitCode output `shouldBe` ExitSuccess
 
     describe ".build" $ do
       it "builds manually specified packages" $ \runGarn -> do
@@ -164,10 +164,10 @@ spec = do
                     .build("echo $SETUP_VAR > $out/build-artifact"),
                 },
               )
-            |]
-          output <- runGarn ["build", "project"]
-          readFile "result/build-artifact" `shouldReturn` "hello from setup\n"
-          exitCode output `shouldBe` ExitSuccess
+          |]
+        output <- runGarn ["build", "project"]
+        readFile "result/build-artifact" `shouldReturn` "hello from setup\n"
+        exitCode output `shouldBe` ExitSuccess
 
     it "includes untracked files when building packages" $ \runGarn -> do
       cmd_ "git init --initial-branch=main" (EchoStdout False)

--- a/ts/check.ts
+++ b/ts/check.ts
@@ -1,4 +1,4 @@
-import { Environment, sandboxScript } from "./environment.ts";
+import { Environment, wrapSandboxedScript } from "./environment.ts";
 import { hasTag } from "./internal/utils.ts";
 import {
   NixExpression,
@@ -30,7 +30,7 @@ export function mkCheck(
 ): Check {
   const checkScript =
     typeof s === "string" ? nixStrLit(s) : nixStrLit(s, ...args);
-  const wrappedScript = sandboxScript(env, checkScript);
+  const wrappedScript = wrapSandboxedScript(env, checkScript);
   return {
     tag: "check",
     nixExpression: nixRaw`

--- a/ts/environment.test.ts
+++ b/ts/environment.test.ts
@@ -11,7 +11,7 @@ import {
   buildPackage,
 } from "./testUtils.ts";
 import { assertStringIncludes } from "https://deno.land/std@0.206.0/assert/assert_string_includes.ts";
-import { addToSandboxSetup, addToSetup } from "./environment.ts";
+import { addToSetup } from "./environment.ts";
 
 describe("environments", () => {
   it("allows creating Executables from shell snippets", () => {
@@ -36,70 +36,83 @@ describe("environments", () => {
     );
   });
 
-  describe("addToSandboxSetup", () => {
-    it("allows adding scripts snippets to the sandbox setup", () => {
-      const env = addToSandboxSetup(
-        garn.emptyEnvironment,
-        'FOO="env var value"',
-      );
-      const path = buildPackage(env.build("echo $FOO > $out/artifact"));
-      assertEquals(
-        Deno.readTextFileSync(`${path}/artifact`),
-        "env var value\n",
-      );
-      assertSuccess(runCheck(env.check('test -n "$FOO"')));
-    });
-
-    it("doesn't affect the underlying environment", () => {
-      const original = addToSandboxSetup(
-        garn.emptyEnvironment,
-        'FOO="original"',
-      );
-      const modified = addToSandboxSetup(original, 'FOO="modified"');
-      let path = buildPackage(original.build("echo $FOO > $out/artifact"));
-      assertEquals(Deno.readTextFileSync(`${path}/artifact`), "original\n");
-      path = buildPackage(modified.build("echo $FOO > $out/artifact"));
-      assertEquals(Deno.readTextFileSync(`${path}/artifact`), "modified\n");
-    });
-
-    it("does not affect Executables", () => {
-      const env = addToSandboxSetup(
-        garn.emptyEnvironment,
-        'FOO="env var value"',
-      );
-      const output = assertSuccess(
-        runExecutable(env.shell('echo executable: "$FOO"')),
-      );
-      assertStdout(output, "executable: \n");
-    });
-  });
-
   describe("addToSetup", () => {
-    it("allows adding scripts snippets to the setup for Packages, Checks & Executables", () => {
-      const env = addToSetup(garn.emptyEnvironment, 'FOO="env var value"');
-      const path = buildPackage(env.build("echo $FOO > $out/artifact"));
-      assertEquals(
-        Deno.readTextFileSync(`${path}/artifact`),
-        "env var value\n",
-      );
-      assertSuccess(runCheck(env.check('test -n "$FOO"')));
-      const output = assertSuccess(
-        runExecutable(env.shell('echo executable: "$FOO"')),
-      );
-      assertStdout(output, "executable: env var value\n");
+    describe('type = "sandbox"', () => {
+      it("allows adding scripts snippets to the sandbox setup", () => {
+        const env = addToSetup(
+          "sandbox",
+          garn.emptyEnvironment,
+          'FOO="env var value"',
+        );
+        const path = buildPackage(env.build("echo $FOO > $out/artifact"));
+        assertEquals(
+          Deno.readTextFileSync(`${path}/artifact`),
+          "env var value\n",
+        );
+        assertSuccess(runCheck(env.check('test -n "$FOO"')));
+      });
+
+      it("doesn't affect the underlying environment", () => {
+        const original = addToSetup(
+          "sandbox",
+          garn.emptyEnvironment,
+          'FOO="original"',
+        );
+        const modified = addToSetup("sandbox", original, 'FOO="modified"');
+        let path = buildPackage(original.build("echo $FOO > $out/artifact"));
+        assertEquals(Deno.readTextFileSync(`${path}/artifact`), "original\n");
+        path = buildPackage(modified.build("echo $FOO > $out/artifact"));
+        assertEquals(Deno.readTextFileSync(`${path}/artifact`), "modified\n");
+      });
+
+      it("does not affect Executables", () => {
+        const env = addToSetup(
+          "sandbox",
+          garn.emptyEnvironment,
+          'FOO="env var value"',
+        );
+        const output = assertSuccess(
+          runExecutable(env.shell('echo executable: "$FOO"')),
+        );
+        assertStdout(output, "executable: \n");
+      });
     });
 
-    it("doesn't affect the underlying environment", () => {
-      const original = addToSetup(garn.emptyEnvironment, 'FOO="original"');
-      const modified = addToSetup(original, 'FOO="modified"');
-      assertStdout(
-        assertSuccess(runExecutable(original.shell("echo $FOO"))),
-        "original\n",
-      );
-      assertStdout(
-        assertSuccess(runExecutable(modified.shell("echo $FOO"))),
-        "modified\n",
-      );
+    describe('type = "common"', () => {
+      it("allows adding scripts snippets to the setup for Packages, Checks & Executables", () => {
+        const env = addToSetup(
+          "common",
+          garn.emptyEnvironment,
+          'FOO="env var value"',
+        );
+        const path = buildPackage(env.build("echo $FOO > $out/artifact"));
+        assertEquals(
+          Deno.readTextFileSync(`${path}/artifact`),
+          "env var value\n",
+        );
+        assertSuccess(runCheck(env.check('test -n "$FOO"')));
+        const output = assertSuccess(
+          runExecutable(env.shell('echo executable: "$FOO"')),
+        );
+        assertStdout(output, "executable: env var value\n");
+      });
+
+      it("doesn't affect the underlying environment", () => {
+        const original = addToSetup(
+          "common",
+          garn.emptyEnvironment,
+          'FOO="original"',
+        );
+        const modified = addToSetup("common", original, 'FOO="modified"');
+        assertStdout(
+          assertSuccess(runExecutable(original.shell("echo $FOO"))),
+          "original\n",
+        );
+        assertStdout(
+          assertSuccess(runExecutable(modified.shell("echo $FOO"))),
+          "modified\n",
+        );
+      });
     });
   });
 

--- a/ts/environment.test.ts
+++ b/ts/environment.test.ts
@@ -35,6 +35,29 @@ describe("environments", () => {
     );
   });
 
+  describe("addToSandboxSetup", () => {
+    it("allows adding scripts snippets to the sandbox setup", () => {
+      const env = garn.emptyEnvironment.addToSandboxSetup(
+        'FOO="env var value"',
+      );
+      const path = buildPackage(env.build("echo $FOO > $out/artifact"));
+      assertEquals(
+        Deno.readTextFileSync(`${path}/artifact`),
+        "env var value\n",
+      );
+    });
+
+    it("doesn't affect the underlying environment", () => {
+      const original =
+        garn.emptyEnvironment.addToSandboxSetup('FOO="original"');
+      const modified = original.addToSandboxSetup('FOO="modified"');
+      let path = buildPackage(original.build("echo $FOO > $out/artifact"));
+      assertEquals(Deno.readTextFileSync(`${path}/artifact`), "original\n");
+      path = buildPackage(modified.build("echo $FOO > $out/artifact"));
+      assertEquals(Deno.readTextFileSync(`${path}/artifact`), "modified\n");
+    });
+  });
+
   describe("environments with source files", () => {
     it("allows accessing source files in Checks", () => {
       const src = Deno.makeTempDirSync();

--- a/ts/environment.test.ts
+++ b/ts/environment.test.ts
@@ -37,10 +37,10 @@ describe("environments", () => {
   });
 
   describe("addToSetup", () => {
-    describe('type = "sandbox"', () => {
+    describe('type = "sandboxed"', () => {
       it("allows adding scripts snippets to the sandbox setup", () => {
         const env = addToSetup(
-          "sandbox",
+          "sandboxed",
           garn.emptyEnvironment,
           'FOO="env var value"',
         );
@@ -54,11 +54,11 @@ describe("environments", () => {
 
       it("doesn't affect the underlying environment", () => {
         const original = addToSetup(
-          "sandbox",
+          "sandboxed",
           garn.emptyEnvironment,
           'FOO="original"',
         );
-        const modified = addToSetup("sandbox", original, 'FOO="modified"');
+        const modified = addToSetup("sandboxed", original, 'FOO="modified"');
         let path = buildPackage(original.build("echo $FOO > $out/artifact"));
         assertEquals(Deno.readTextFileSync(`${path}/artifact`), "original\n");
         path = buildPackage(modified.build("echo $FOO > $out/artifact"));
@@ -67,7 +67,7 @@ describe("environments", () => {
 
       it("does not affect Executables", () => {
         const env = addToSetup(
-          "sandbox",
+          "sandboxed",
           garn.emptyEnvironment,
           'FOO="env var value"',
         );
@@ -78,10 +78,10 @@ describe("environments", () => {
       });
     });
 
-    describe('type = "common"', () => {
+    describe('type = "unsandboxed"', () => {
       it("allows adding scripts snippets to the setup for Packages, Checks & Executables", () => {
         const env = addToSetup(
-          "common",
+          "unsandboxed",
           garn.emptyEnvironment,
           'FOO="env var value"',
         );
@@ -99,11 +99,11 @@ describe("environments", () => {
 
       it("doesn't affect the underlying environment", () => {
         const original = addToSetup(
-          "common",
+          "unsandboxed",
           garn.emptyEnvironment,
           'FOO="original"',
         );
-        const modified = addToSetup("common", original, 'FOO="modified"');
+        const modified = addToSetup("unsandboxed", original, 'FOO="modified"');
         assertStdout(
           assertSuccess(runExecutable(original.shell("echo $FOO"))),
           "original\n",

--- a/ts/environment.ts
+++ b/ts/environment.ts
@@ -31,9 +31,16 @@ export type Environment = {
    * Update the description for this `Environment`
    */
   setDescription: (this: Environment, newDescription: string) => Environment;
-
   /**
-   * Creates a new environment based on this one that includes the specified nix packages.
+   * Appends the given bash snippet to the sandbox setup. The sandbox setup will
+   * be executed when setting up the environment for deterministic sandboxes.
+   * I.e. before every `Check` is run and before every `Package` is built. It's
+   * *not* run when for `garn run` or `garn enter`.
+   */
+  addToSandboxSetup(snippet: string): Environment;
+  /**
+   * Creates a new environment based on this one that includes the specified nix
+   * packages.
    */
   withDevTools(devTools: Array<Package>): Environment;
   /**
@@ -53,7 +60,8 @@ export type Environment = {
     ..._args: Array<NixStrLitInterpolatable>
   ): Check;
   /**
-   * Creates a new `Package` built with the given shell script, run inside this `Environment`
+   * Creates a new `Package` built with the given shell script, run inside this
+   * `Environment`
    */
   build(build: string): Package;
   build(
@@ -178,6 +186,12 @@ export function mkEnvironment(
       return {
         ...this,
         description: newDescription,
+      };
+    },
+    addToSandboxSetup(this: Environment, snippet: string): Environment {
+      return {
+        ...this,
+        sandboxSetup: nixStrLit`${this.sandboxSetup}\n${snippet}`,
       };
     },
     check(

--- a/ts/environment.ts
+++ b/ts/environment.ts
@@ -7,7 +7,7 @@ import {
   nixList,
   nixRaw,
   nixStrLit,
-  unlinesNixStrings,
+  joinNixStrings,
 } from "./nix.ts";
 import { Package, mkShellPackage } from "./package.ts";
 
@@ -93,7 +93,7 @@ export const commonScript = (
   env: Environment,
   script: NixExpression,
 ): NixExpression =>
-  unlinesNixStrings([
+  joinNixStrings("\n", [
     ...env.setup.filter((x) => x.tag === "common").map((x) => x.snippet),
     script,
   ]);
@@ -102,7 +102,7 @@ export const sandboxScript = (
   env: Environment,
   script: NixExpression,
 ): NixExpression =>
-  unlinesNixStrings([
+  joinNixStrings("\n", [
     nixStrLit`mkdir -p $out`,
     ...env.setup.map((x) => x.snippet),
     script,

--- a/ts/environment.ts
+++ b/ts/environment.ts
@@ -107,10 +107,13 @@ export const commonScript = (
   env: Environment,
   script: NixExpression,
 ): NixExpression =>
-  joinNixStrings("\n", [
-    ...env.setup.filter((x) => x.type === "common").map((x) => x.snippet),
-    script,
-  ]);
+  joinNixStrings(
+    [
+      ...env.setup.filter((x) => x.type === "common").map((x) => x.snippet),
+      script,
+    ],
+    "\n",
+  );
 
 /**
  * Add the sandbox setup of an `Environment` to a given script. This should be
@@ -120,11 +123,10 @@ export const sandboxScript = (
   env: Environment,
   script: NixExpression,
 ): NixExpression =>
-  joinNixStrings("\n", [
-    nixStrLit`mkdir -p $out`,
-    ...env.setup.map((x) => x.snippet),
-    script,
-  ]);
+  joinNixStrings(
+    [nixStrLit`mkdir -p $out`, ...env.setup.map((x) => x.snippet), script],
+    "\n",
+  );
 
 /**
  * Creates a new shell script `Executable`, run in the `emptyEnvironment`.

--- a/ts/environment.ts
+++ b/ts/environment.ts
@@ -79,8 +79,7 @@ export type Environment = {
     ..._args: Array<NixStrLitInterpolatable>
   ): Check;
   /**
-   * Creates a new `Package` built with the given shell script, run inside this
-   * `Environment`
+   * Creates a new `Package` built with the given shell script, run inside this `Environment`
    */
   build(build: string): Package;
   build(

--- a/ts/executable.ts
+++ b/ts/executable.ts
@@ -6,7 +6,7 @@ import {
   NixStrLitInterpolatable,
   toHumanReadable,
 } from "./nix.ts";
-import { Environment } from "./environment.ts";
+import { commonScript, Environment } from "./environment.ts";
 
 /**
  * `Executable`s are commands (usually shell snippets) that are being run on
@@ -71,8 +71,10 @@ export function mkShellExecutable(
   s: TemplateStringsArray | string,
   ...args: Array<NixStrLitInterpolatable>
 ): Executable {
-  const cmdToExecute =
-    typeof s === "string" ? nixStrLit(s) : nixStrLit(s, ...args);
+  const cmdToExecute = commonScript(
+    env,
+    typeof s === "string" ? nixStrLit(s) : nixStrLit(s, ...args),
+  );
   const shellEnv = nixRaw`
       let
         dev = ${env.nixExpression};

--- a/ts/executable.ts
+++ b/ts/executable.ts
@@ -6,7 +6,7 @@ import {
   NixStrLitInterpolatable,
   toHumanReadable,
 } from "./nix.ts";
-import { commonScript, Environment } from "./environment.ts";
+import { wrapUnsandboxedScript, Environment } from "./environment.ts";
 
 /**
  * `Executable`s are commands (usually shell snippets) that are being run on
@@ -71,7 +71,7 @@ export function mkShellExecutable(
   s: TemplateStringsArray | string,
   ...args: Array<NixStrLitInterpolatable>
 ): Executable {
-  const cmdToExecute = commonScript(
+  const cmdToExecute = wrapUnsandboxedScript(
     env,
     typeof s === "string" ? nixStrLit(s) : nixStrLit(s, ...args),
   );

--- a/ts/javascript/mod.ts
+++ b/ts/javascript/mod.ts
@@ -82,7 +82,7 @@ export function mkNpmProject(args: {
     "node_modules",
   );
   const devShell: Environment = addToSetup(
-    "sandbox",
+    "sandboxed",
     mkEnvironment({
       src: args.src,
     }),

--- a/ts/javascript/mod.ts
+++ b/ts/javascript/mod.ts
@@ -83,12 +83,15 @@ export function mkNpmProject(args: {
   );
   const devShell: Environment = mkEnvironment({
     src: args.src,
-    sandboxSetup: nixStrLit`
-      echo copying node_modules
-      cp -r ${node_modules}/node_modules .
-      chmod -R u+rwX node_modules
-    `,
-  }).withDevTools([mkPackage(nodejs, "nodejs")]);
+  })
+    .addToSandboxSetup(
+      nixStrLit`
+        echo copying node_modules
+        cp -r ${node_modules}/node_modules .
+        chmod -R u+rwX node_modules
+      `,
+    )
+    .withDevTools([mkPackage(nodejs, "nodejs")]);
   return mkProject(
     {
       description: args.description,

--- a/ts/javascript/mod.ts
+++ b/ts/javascript/mod.ts
@@ -1,8 +1,4 @@
-import {
-  Environment,
-  addToSandboxSetup,
-  mkEnvironment,
-} from "../environment.ts";
+import { Environment, addToSetup, mkEnvironment } from "../environment.ts";
 import { Executable } from "../executable.ts";
 import { mkPackage, Package } from "../package.ts";
 import { mkProject, Project } from "../project.ts";
@@ -85,7 +81,8 @@ export function mkNpmProject(args: {
     `,
     "node_modules",
   );
-  const devShell: Environment = addToSandboxSetup(
+  const devShell: Environment = addToSetup(
+    "sandbox",
     mkEnvironment({
       src: args.src,
     }),

--- a/ts/javascript/mod.ts
+++ b/ts/javascript/mod.ts
@@ -1,4 +1,8 @@
-import { Environment, mkEnvironment } from "../environment.ts";
+import {
+  Environment,
+  addToSandboxSetup,
+  mkEnvironment,
+} from "../environment.ts";
 import { Executable } from "../executable.ts";
 import { mkPackage, Package } from "../package.ts";
 import { mkProject, Project } from "../project.ts";
@@ -81,17 +85,16 @@ export function mkNpmProject(args: {
     `,
     "node_modules",
   );
-  const devShell: Environment = mkEnvironment({
-    src: args.src,
-  })
-    .addToSandboxSetup(
-      nixStrLit`
+  const devShell: Environment = addToSandboxSetup(
+    mkEnvironment({
+      src: args.src,
+    }),
+    nixStrLit`
         echo copying node_modules
         cp -r ${node_modules}/node_modules .
         chmod -R u+rwX node_modules
       `,
-    )
-    .withDevTools([mkPackage(nodejs, "nodejs")]);
+  ).withDevTools([mkPackage(nodejs, "nodejs")]);
   return mkProject(
     {
       description: args.description,

--- a/ts/nix.test.ts
+++ b/ts/nix.test.ts
@@ -37,19 +37,19 @@ Deno.test("nixStrLit correctly serializes into a nix expression", () => {
 });
 
 Deno.test("joinNixStrings joins strings using the given separator", () => {
-  assertEquals(renderNixExpression(joinNixStrings("sep", [])), '""');
+  assertEquals(renderNixExpression(joinNixStrings([], "sep")), '""');
   assertEquals(
     renderNixExpression(
-      joinNixStrings("sep", [nixStrLit`foo ${nixRaw`42`} bar`]),
+      joinNixStrings([nixStrLit`foo ${nixRaw`42`} bar`], "sep"),
     ),
     '"${"foo ${42} bar"}"',
   );
   assertEquals(
     renderNixExpression(
-      joinNixStrings("sep", [
-        nixStrLit`foo ${nixRaw`42`} bar`,
-        nixStrLit`baz ${nixRaw`23`} boo`,
-      ]),
+      joinNixStrings(
+        [nixStrLit`foo ${nixRaw`42`} bar`, nixStrLit`baz ${nixRaw`23`} boo`],
+        "sep",
+      ),
     ),
     '"${"foo ${42} bar"}sep${"baz ${23} boo"}"',
   );

--- a/ts/nix.test.ts
+++ b/ts/nix.test.ts
@@ -11,7 +11,7 @@ import {
   renderNixExpression,
   renderFlakeFile,
   nixFlakeDep,
-  unlinesNixStrings,
+  joinNixStrings,
 } from "./nix.ts";
 
 Deno.test("nixStrLit correctly serializes into a nix expression", () => {
@@ -36,27 +36,24 @@ Deno.test("nixStrLit correctly serializes into a nix expression", () => {
   );
 });
 
-Deno.test(
-  "unlinesNixStrings creates a new string literal with all given lines spliced in",
-  () => {
-    assertEquals(renderNixExpression(unlinesNixStrings([])), '""');
-    assertEquals(
-      renderNixExpression(
-        unlinesNixStrings([nixStrLit`foo ${nixRaw`42`} bar`]),
-      ),
-      '"${"foo ${42} bar"}\n"',
-    );
-    assertEquals(
-      renderNixExpression(
-        unlinesNixStrings([
-          nixStrLit`foo ${nixRaw`42`} bar`,
-          nixStrLit`baz ${nixRaw`23`} boo`,
-        ]),
-      ),
-      '"${"foo ${42} bar"}\n${"baz ${23} boo"}\n"',
-    );
-  },
-);
+Deno.test("joinNixStrings joins strings using the given separator", () => {
+  assertEquals(renderNixExpression(joinNixStrings("sep", [])), '""');
+  assertEquals(
+    renderNixExpression(
+      joinNixStrings("sep", [nixStrLit`foo ${nixRaw`42`} bar`]),
+    ),
+    '"${"foo ${42} bar"}"',
+  );
+  assertEquals(
+    renderNixExpression(
+      joinNixStrings("sep", [
+        nixStrLit`foo ${nixRaw`42`} bar`,
+        nixStrLit`baz ${nixRaw`23`} boo`,
+      ]),
+    ),
+    '"${"foo ${42} bar"}sep${"baz ${23} boo"}"',
+  );
+});
 
 Deno.test(
   "toHumanReadable snips out incedental dependencies in string literals",

--- a/ts/nix.ts
+++ b/ts/nix.ts
@@ -197,16 +197,13 @@ export function nixStrLit(
 }
 
 export function joinNixStrings(
-  separator: string,
-  list: Array<NixExpression>,
+  arr: Array<NixExpression>,
+  joiner: string,
 ): NixExpression {
   return {
     [__nixExpressionTag]: null,
     type: "strLit",
-    str: {
-      initial: "",
-      rest: list.map((expr, i) => [expr, i < list.length - 1 ? separator : ""]),
-    },
+    str: join(arr, joiner),
   };
 }
 

--- a/ts/nix.ts
+++ b/ts/nix.ts
@@ -196,13 +196,16 @@ export function nixStrLit(
   };
 }
 
-export function unlinesNixStrings(list: Array<NixExpression>): NixExpression {
+export function joinNixStrings(
+  separator: string,
+  list: Array<NixExpression>,
+): NixExpression {
   return {
     [__nixExpressionTag]: null,
     type: "strLit",
     str: {
       initial: "",
-      rest: list.map((expr) => [expr, "\n"]),
+      rest: list.map((expr, i) => [expr, i < list.length - 1 ? separator : ""]),
     },
   };
 }

--- a/ts/package.ts
+++ b/ts/package.ts
@@ -1,4 +1,4 @@
-import { Environment, sandboxScript, shell } from "./environment.ts";
+import { Environment, wrapSandboxedScript, shell } from "./environment.ts";
 import { Executable } from "./executable.ts";
 import { hasTag } from "./internal/utils.ts";
 import {
@@ -74,7 +74,7 @@ export function mkShellPackage(
 ) {
   const cmdToExecute =
     typeof s === "string" ? nixStrLit(s) : nixStrLit(s, ...args);
-  const wrappedScript = sandboxScript(env, cmdToExecute);
+  const wrappedScript = wrapSandboxedScript(env, cmdToExecute);
   const pkg = nixRaw`
     let dev = ${env.nixExpression}; in
     pkgs.runCommand "garn-pkg" {

--- a/website/flake.nix
+++ b/website/flake.nix
@@ -79,9 +79,8 @@
                 buildInputs = dev.buildInputs ++ dev.nativeBuildInputs;
               } "${"mkdir -p \$out"}
 ${"
-      ${"
-    echo copying source
-    cp -r ${(let
+                echo copying source
+                cp -r ${(let
     lib = pkgs.lib;
     lastSafe = list :
       if lib.lists.length list == 0
@@ -99,11 +98,11 @@ ${"
          fileName != "flake.nix" &&
          fileName != "garn.ts";
     })}/. .
-    chmod -R u+rwX .
-  "}
-      ${"
-      echo copying node_modules
-      cp -r ${let
+                chmod -R u+rwX .
+              "}
+${"
+        echo copying node_modules
+        cp -r ${let
         npmlock2nix = import npmlock2nix-repo {
           inherit pkgs;
         };
@@ -134,11 +133,9 @@ ${"
     });
           nodejs = pkgs.nodejs-18_x;
         }}/node_modules .
-      chmod -R u+rwX node_modules
-    "}
-    "}
-${"npm run tsc"}
-";
+        chmod -R u+rwX node_modules
+      "}
+${"npm run tsc"}";
           "website/fmt-check" =
             let
               dev = ((pkgs.mkShell { }).overrideAttrs (finalAttrs: previousAttrs: {
@@ -158,9 +155,8 @@ ${"npm run tsc"}
                 buildInputs = dev.buildInputs ++ dev.nativeBuildInputs;
               } "${"mkdir -p \$out"}
 ${"
-      ${"
-    echo copying source
-    cp -r ${(let
+                echo copying source
+                cp -r ${(let
     lib = pkgs.lib;
     lastSafe = list :
       if lib.lists.length list == 0
@@ -178,11 +174,11 @@ ${"
          fileName != "flake.nix" &&
          fileName != "garn.ts";
     })}/. .
-    chmod -R u+rwX .
-  "}
-      ${"
-      echo copying node_modules
-      cp -r ${let
+                chmod -R u+rwX .
+              "}
+${"
+        echo copying node_modules
+        cp -r ${let
         npmlock2nix = import npmlock2nix-repo {
           inherit pkgs;
         };
@@ -213,11 +209,9 @@ ${"
     });
           nodejs = pkgs.nodejs-18_x;
         }}/node_modules .
-      chmod -R u+rwX node_modules
-    "}
-    "}
-${"prettier '**/*.{ts,tsx}' --check"}
-";
+        chmod -R u+rwX node_modules
+      "}
+${"prettier '**/*.{ts,tsx}' --check"}";
         }
       );
       devShells = forAllSystems (system:
@@ -263,7 +257,7 @@ ${"prettier '**/*.{ts,tsx}' --check"}
             ++
             [(pkgs.nodePackages.typescript-language-server) (pkgs.nodePackages.prettier)];
         });
-        shell = "npm install ; npm run build";
+        shell = "${"npm install ; npm run build"}";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";
@@ -289,7 +283,7 @@ ${"prettier '**/*.{ts,tsx}' --check"}
             ++
             [(pkgs.nodePackages.typescript-language-server) (pkgs.nodePackages.prettier)];
         });
-        shell = "npm install ; npm run dev";
+        shell = "${"npm install ; npm run dev"}";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";
@@ -315,7 +309,7 @@ ${"prettier '**/*.{ts,tsx}' --check"}
             ++
             [(pkgs.nodePackages.typescript-language-server) (pkgs.nodePackages.prettier)];
         });
-        shell = "prettier '**/*.{ts,tsx}' --write";
+        shell = "${"prettier '**/*.{ts,tsx}' --write"}";
         buildPath = pkgs.runCommand "build-inputs-path" {
           inherit (dev) buildInputs nativeBuildInputs;
         } "echo $PATH > $out";


### PR DESCRIPTION
This PR changes how `Environment`s set up scripts, both in the build sandboxes and outside of them. Most importantly it allows to *have* a setup for `Executable`s and `garn enter`. This would allow us to experiment with e.g. modifying the `$PATH` to add `node_modules/.bin` and similar things.

I'm not sure this is the best API, so ideas for improvements are very welcome. Also, I think the naming of everything could be better and more consistent.