### PR TITLE
Add test to verify `docland` for garn works

### DIFF
--- a/justfile
+++ b/justfile
@@ -113,7 +113,7 @@ hpack-check:
       error "package.yaml has changed, please run hpack"
 
 test-ts *args="":
-  deno test --check --parallel --allow-write --allow-read --allow-run ts/*.test.ts ts/**/*.test.ts {{ args }}
+  deno test --check --parallel --allow-write --allow-read --allow-run --allow-net ts/*.test.ts ts/**/*.test.ts {{ args }}
 
 test *args="": hpack
   cabal run --test-show-details=streaming garn:spec -- {{ args }}

--- a/ts/internal/docland.test.ts
+++ b/ts/internal/docland.test.ts
@@ -1,0 +1,11 @@
+// This is the dependency file of the repo deployed at doc.deno.land. We import
+// deno_doc's `doc` here to check if our modules are parsable by the verison of
+// deno_doc used by docland.
+import { doc } from "https://raw.githubusercontent.com/denoland/docland/main/deps.ts";
+import { describe, it } from "https://deno.land/std@0.206.0/testing/bdd.ts";
+
+describe("docland", () => {
+  it("is able to generate documentation for mod.ts", async () => {
+    await doc("http://localhost:8777/mod.ts");
+  });
+});

--- a/ts/internal/docland.test.ts
+++ b/ts/internal/docland.test.ts
@@ -1,5 +1,5 @@
 // This is the dependency file of the repo deployed at doc.deno.land. We import
-// deno_doc's `doc` here to check if our modules are parsable by the verison of
+// deno_doc's `doc` here to check if our modules are parsable by the version of
 // deno_doc used by docland.
 import { doc } from "https://raw.githubusercontent.com/denoland/docland/main/deps.ts";
 import { describe, it } from "https://deno.land/std@0.206.0/testing/bdd.ts";

--- a/ts/internal/docland.test.ts
+++ b/ts/internal/docland.test.ts
@@ -6,6 +6,6 @@ import { describe, it } from "https://deno.land/std@0.206.0/testing/bdd.ts";
 
 describe("docland", () => {
   it("is able to generate documentation for mod.ts", async () => {
-    await doc("http://localhost:8777/mod.ts");
+    await doc(new URL("../mod.ts", import.meta.url).toString());
   });
 });


### PR DESCRIPTION
`docland` uses an older version of `deno_doc` which doesn't support all the newest features of typescript. This tests verifies that pushing such a change results in a CI error.