### PR TITLE
Build the website2 bundle on CI

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,12 @@
             pkgs.lib.attrsets.mapAttrs'
               (name: value: { name = "website_${name}"; inherit value; })
               websiteFlake.packages.${system} else { };
+        website2Flake = call-flake ./website2;
+        website2Packages =
+          if system == "x86_64-linux" then
+            pkgs.lib.attrsets.mapAttrs'
+              (name: value: { name = "website2_${name}"; inherit value; })
+              website2Flake.packages.${system} else { };
       in
       {
         lib = pkgs.lib;
@@ -161,6 +167,7 @@
             '');
         }
         // websitePackages
+        // website2Packages
         // (
           if system == "x86_64-linux"
           then {
@@ -218,6 +225,11 @@
                 pkgs.lib.attrsets.mapAttrs'
                   (name: check: { name = "website_${name}"; value = check; })
                   websiteFlake.checks.${system} else { };
+            website2Checks =
+              if system == "x86_64-linux" then
+                pkgs.lib.attrsets.mapAttrs'
+                  (name: check: { name = "website2_${name}"; value = check; })
+                  website2Flake.checks.${system} else { };
           in
           {
             nix-fmt = justRecipe "fmt-nix-check" [ self.formatter.${system} ];
@@ -237,7 +249,9 @@
               fileserver --help
               touch $out
             '';
-          } // websiteChecks;
+          }
+          // websiteChecks
+          // website2Checks;
         formatter = pkgs.nixpkgs-fmt;
         apps = {
           fileserver = flake-utils.lib.mkApp

--- a/justfile
+++ b/justfile
@@ -146,7 +146,7 @@ check-examples:
 
 update-flakefiles:
   #!/usr/bin/env bash
-  for EXAMPLE in examples/* website; do
+  for EXAMPLE in examples/* website website2; do
     if [ -e "$EXAMPLE/garn.ts" ]; then
       (
         cd "$EXAMPLE"

--- a/website2/flake.lock
+++ b/website2/flake.lock
@@ -1,0 +1,45 @@
+{
+  "nodes": {
+    "nixpkgs-repo": {
+      "locked": {
+        "lastModified": 1698376214,
+        "narHash": "sha256-8UC0cK/cT600ug+8RVc6a1sE66+U1dfsileTo65zPCg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6fc7203e423bbf1c8f84cccf1c4818d097612566",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6fc7203e423bbf1c8f84cccf1c4818d097612566",
+        "type": "github"
+      }
+    },
+    "npmlock2nix-repo": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673447413,
+        "narHash": "sha256-sJM82Sj8yfQYs9axEmGZ9Evzdv/kDcI9sddqJ45frrU=",
+        "owner": "nix-community",
+        "repo": "npmlock2nix",
+        "rev": "9197bbf397d76059a76310523d45df10d2e4ca81",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "npmlock2nix",
+        "rev": "9197bbf397d76059a76310523d45df10d2e4ca81",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs-repo": "nixpkgs-repo",
+        "npmlock2nix-repo": "npmlock2nix-repo"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/website2/flake.nix
+++ b/website2/flake.nix
@@ -1,0 +1,239 @@
+{
+  inputs.nixpkgs-repo.url = "github:NixOS/nixpkgs/6fc7203e423bbf1c8f84cccf1c4818d097612566";
+  inputs.npmlock2nix-repo = { url = "github:nix-community/npmlock2nix?rev=9197bbf397d76059a76310523d45df10d2e4ca81"; flake = false; };
+  outputs = { self, nixpkgs-repo, npmlock2nix-repo }:
+    let
+      nixpkgs = nixpkgs-repo;
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = import "${nixpkgs}" {
+            config.allowUnfree = true;
+            inherit system;
+          };
+        in
+        {
+          "website2/node_modules" =
+            let
+              npmlock2nix = import npmlock2nix-repo {
+                inherit pkgs;
+              };
+              pkgs = import nixpkgs-repo {
+                config.permittedInsecurePackages = [ ];
+                inherit system;
+              };
+            in
+            npmlock2nix.v2.node_modules
+              {
+                src = (
+                  let
+                    lib = pkgs.lib;
+                    lastSafe = list:
+                      if lib.lists.length list == 0
+                      then null
+                      else lib.lists.last list;
+                  in
+                  builtins.path
+                    {
+                      path = ./.;
+                      name = "source";
+                      filter = path: type:
+                        let
+                          fileName = lastSafe (lib.strings.splitString "/" path);
+                        in
+                        fileName != "flake.nix" &&
+                        fileName != "garn.ts";
+                    }
+                );
+                nodejs = pkgs.nodejs-18_x;
+              };
+          "website2/bundle" =
+            let
+              dev = (pkgs.mkShell { }).overrideAttrs (finalAttrs: previousAttrs: {
+                nativeBuildInputs =
+                  previousAttrs.nativeBuildInputs
+                  ++
+                  [ (pkgs.nodejs-18_x) ];
+              });
+            in
+            pkgs.runCommand "garn-pkg"
+              {
+                buildInputs = dev.buildInputs ++ dev.nativeBuildInputs;
+              } "${"mkdir -p \$out"}
+${"
+      ${"
+    echo copying source
+    cp -r ${(let
+    lib = pkgs.lib;
+    lastSafe = list :
+      if lib.lists.length list == 0
+        then null
+        else lib.lists.last list;
+  in
+  builtins.path
+    {
+      path = ./.;
+      name = "source";
+      filter = path: type:
+        let
+          fileName = lastSafe (lib.strings.splitString "/" path);
+        in
+         fileName != "flake.nix" &&
+         fileName != "garn.ts";
+    })}/. .
+    chmod -R u+rwX .
+  "}
+      ${"
+      echo copying node_modules
+      cp -r ${let
+        npmlock2nix = import npmlock2nix-repo {
+          inherit pkgs;
+        };
+        pkgs = import nixpkgs-repo {
+        config.permittedInsecurePackages = [];
+        inherit system;
+      };
+      in
+      npmlock2nix.v2.node_modules
+        {
+          src = (let
+    lib = pkgs.lib;
+    lastSafe = list :
+      if lib.lists.length list == 0
+        then null
+        else lib.lists.last list;
+  in
+  builtins.path
+    {
+      path = ./.;
+      name = "source";
+      filter = path: type:
+        let
+          fileName = lastSafe (lib.strings.splitString "/" path);
+        in
+         fileName != "flake.nix" &&
+         fileName != "garn.ts";
+    });
+          nodejs = pkgs.nodejs-18_x;
+        }}/node_modules .
+      chmod -R u+rwX node_modules
+    "}
+    "}
+${"npm run build ; mv out/* \$out/"}
+";
+        }
+      );
+      checks = forAllSystems (system:
+        let
+          pkgs = import "${nixpkgs}" {
+            config.allowUnfree = true;
+            inherit system;
+          };
+        in
+        {
+          "website2/lint" =
+            let
+              dev = (pkgs.mkShell { }).overrideAttrs (finalAttrs: previousAttrs: {
+                nativeBuildInputs =
+                  previousAttrs.nativeBuildInputs
+                  ++
+                  [ (pkgs.nodejs-18_x) ];
+              });
+            in
+            pkgs.runCommand "check"
+              {
+                buildInputs = dev.buildInputs ++ dev.nativeBuildInputs;
+              } "${"mkdir -p \$out"}
+${"
+      ${"
+    echo copying source
+    cp -r ${(let
+    lib = pkgs.lib;
+    lastSafe = list :
+      if lib.lists.length list == 0
+        then null
+        else lib.lists.last list;
+  in
+  builtins.path
+    {
+      path = ./.;
+      name = "source";
+      filter = path: type:
+        let
+          fileName = lastSafe (lib.strings.splitString "/" path);
+        in
+         fileName != "flake.nix" &&
+         fileName != "garn.ts";
+    })}/. .
+    chmod -R u+rwX .
+  "}
+      ${"
+      echo copying node_modules
+      cp -r ${let
+        npmlock2nix = import npmlock2nix-repo {
+          inherit pkgs;
+        };
+        pkgs = import nixpkgs-repo {
+        config.permittedInsecurePackages = [];
+        inherit system;
+      };
+      in
+      npmlock2nix.v2.node_modules
+        {
+          src = (let
+    lib = pkgs.lib;
+    lastSafe = list :
+      if lib.lists.length list == 0
+        then null
+        else lib.lists.last list;
+  in
+  builtins.path
+    {
+      path = ./.;
+      name = "source";
+      filter = path: type:
+        let
+          fileName = lastSafe (lib.strings.splitString "/" path);
+        in
+         fileName != "flake.nix" &&
+         fileName != "garn.ts";
+    });
+          nodejs = pkgs.nodejs-18_x;
+        }}/node_modules .
+      chmod -R u+rwX node_modules
+    "}
+    "}
+${"npm run lint"}
+";
+        }
+      );
+      devShells = forAllSystems (system:
+        let
+          pkgs = import "${nixpkgs}" {
+            config.allowUnfree = true;
+            inherit system;
+          };
+        in
+        {
+          "website2" = (pkgs.mkShell { }).overrideAttrs (finalAttrs: previousAttrs: {
+            nativeBuildInputs =
+              previousAttrs.nativeBuildInputs
+              ++
+              [ (pkgs.nodejs-18_x) ];
+          });
+        }
+      );
+      apps = forAllSystems (system:
+        let
+          pkgs = import "${nixpkgs}" {
+            config.allowUnfree = true;
+            inherit system;
+          };
+        in
+        { }
+      );
+    };
+}

--- a/website2/garn.ts
+++ b/website2/garn.ts
@@ -1,0 +1,10 @@
+import * as garn from "../ts/mod.ts";
+
+export const website2 = garn.javascript
+  .mkNpmProject({
+    description: "garn website rewrite",
+    src: ".",
+    nodeVersion: "18",
+  })
+  .addPackage("bundle", "npm run build ; mv out/* $out/")
+  .addCheck("lint", "npm run lint");

--- a/website2/next.config.js
+++ b/website2/next.config.js
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  output: "export",
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/website2/tsconfig.json
+++ b/website2/tsconfig.json
@@ -26,5 +26,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "garn.ts"]
 }


### PR DESCRIPTION
This PR adds a `garn.ts` file to the `website2` directory and plugs that into the top-level `flake.nix` file to build the html bundle on ci.

@ericyliu: You can (hopefully) just ignore the `garn.ts`, `flake.nix` & `flake.lock` file. Let us know if this breaks CI for you or if you have other questions or problems.

Fixes #485 