### PR TITLE
Documentation page header

### DIFF
--- a/website2/src/app/documentation/page.tsx
+++ b/website2/src/app/documentation/page.tsx
@@ -1,0 +1,15 @@
+import { DocumentationHeader } from "@/components/documentationPage/documentationHeader";
+import { Footer } from "@/components/footer";
+import { Header } from "@/components/header";
+
+const Documentation = () => {
+  return (
+    <main>
+      <Header />
+      <DocumentationHeader />
+      <Footer />
+    </main>
+  );
+};
+
+export default Documentation;

--- a/website2/src/components/documentationPage/documentationHeader/index.tsx
+++ b/website2/src/components/documentationPage/documentationHeader/index.tsx
@@ -1,0 +1,10 @@
+import { Text } from "@/components/text";
+import styles from "./styles.module.css";
+
+export const DocumentationHeader = () => {
+  return (
+    <section className={styles.container}>
+      <Text type="h1">Documentation</Text>
+    </section>
+  );
+};

--- a/website2/src/components/documentationPage/documentationHeader/styles.module.css
+++ b/website2/src/components/documentationPage/documentationHeader/styles.module.css
@@ -1,0 +1,11 @@
+.container {
+  padding: 96px 96px 80px;
+  border-bottom: 2px solid var(--color-black);
+  text-transform: uppercase;
+}
+
+@media only screen and (max-width: 768px) {
+  .container {
+    padding: 40px 16px;
+  }
+}


### PR DESCRIPTION
pretty simple component, skipping the the search and hamburger menu for now

<img width="336" alt="Screenshot 2023-12-11 at 6 53 56 PM" src="https://github.com/garnix-io/garn/assets/8580080/cc02691c-1990-4874-987e-204a41f59cb1">

