### PR TITLE
Documentation anchor tags

### DIFF
--- a/website2/src/components/documentationPage/document/index.tsx
+++ b/website2/src/components/documentationPage/document/index.tsx
@@ -5,6 +5,9 @@ import styles from "./styles.module.css";
 import { SampleCode } from "@/components/sampleCode";
 import { Berlin } from "@/utils/fonts";
 import { ToolTip } from "@/components/tooltip/";
+import Link from "next/link";
+import { Share } from "@/components/icons/share";
+import { DocumentHeader } from "../documentHeader";
 
 type Props = {
   source: string;
@@ -34,28 +37,20 @@ export const Document = ({ source }: Props) => {
               {props.children}
             </Text>
           ),
-          h1: (props) => (
-            <Text type="h1" {...props}>
-              {props.children}
-            </Text>
-          ),
+          h1: (props) => <DocumentHeader type="h1" {...props} />,
           h2: (props) => (
-            <Text
+            <DocumentHeader
               type="h2"
               {...props}
               className={`${props.className} ${styles.h2}`}
-            >
-              {props.children}
-            </Text>
+            />
           ),
           h3: (props) => (
-            <Text
+            <DocumentHeader
               type="h3"
               {...props}
               className={`${props.className} ${styles.h3}`}
-            >
-              {props.children}
-            </Text>
+            />
           ),
           ul: (props) => (
             <ul

--- a/website2/src/components/documentationPage/documentHeader/index.tsx
+++ b/website2/src/components/documentationPage/documentHeader/index.tsx
@@ -1,5 +1,5 @@
 import { Text } from "@/components/text";
-import { PropsWithChildren, ReactNode } from "react";
+import { PropsWithChildren, ReactNode, isValidElement } from "react";
 import styles from "./styles.module.css";
 import { Share } from "@/components/icons/share";
 import Link from "next/link";
@@ -27,5 +27,16 @@ export const DocumentHeader = ({ type, children, ...rest }: Props) => {
 };
 
 const getId = (children: ReactNode): string => {
-children.toLowerCase().replace(/[^a-zA-Z0-9]+/g, "-")
+  if (!children) return "undefined";
+  if (["string", "number"].includes(typeof children))
+    return `${children}`
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-zA-Z0-9]+/g, "-");
+  else if (children instanceof Array) {
+    return children.map(getId).join("-");
+  } else if (isValidElement(children)) {
+    return getId(children.props.children);
+  }
+  return children.toString();
 };

--- a/website2/src/components/documentationPage/documentHeader/index.tsx
+++ b/website2/src/components/documentationPage/documentHeader/index.tsx
@@ -19,7 +19,7 @@ export const DocumentHeader = ({ type, children, ...rest }: Props) => {
       className={`${rest.className} ${styles.container}`}
     >
       <Link href={`#${id}`} className={styles.link}>
-        {children}
+        <span>{children}</span>
         <Share className={styles.share} />
       </Link>
     </Text>

--- a/website2/src/components/documentationPage/documentHeader/index.tsx
+++ b/website2/src/components/documentationPage/documentHeader/index.tsx
@@ -1,0 +1,31 @@
+import { Text } from "@/components/text";
+import { PropsWithChildren, ReactNode } from "react";
+import styles from "./styles.module.css";
+import { Share } from "@/components/icons/share";
+import Link from "next/link";
+
+type Props = PropsWithChildren & {
+  type: "h1" | "h2" | "h3";
+  className?: string;
+};
+
+export const DocumentHeader = ({ type, children, ...rest }: Props) => {
+  const id = getId(children);
+  return (
+    <Text
+      id={id}
+      type={type}
+      {...rest}
+      className={`${rest.className} ${styles.container}`}
+    >
+      <Link href={`#${id}`} className={styles.link}>
+        {children}
+        <Share className={styles.share} />
+      </Link>
+    </Text>
+  );
+};
+
+const getId = (children: ReactNode): string => {
+  return children?.toString().toLowerCase().split(" ").join("-") || "";
+};

--- a/website2/src/components/documentationPage/documentHeader/index.tsx
+++ b/website2/src/components/documentationPage/documentHeader/index.tsx
@@ -27,5 +27,5 @@ export const DocumentHeader = ({ type, children, ...rest }: Props) => {
 };
 
 const getId = (children: ReactNode): string => {
-  return children?.toString().toLowerCase().split(" ").join("-") || "";
+children.toLowerCase().replace(/[^a-zA-Z0-9]+/g, "-")
 };

--- a/website2/src/components/documentationPage/documentHeader/styles.module.css
+++ b/website2/src/components/documentationPage/documentHeader/styles.module.css
@@ -1,0 +1,19 @@
+.link {
+  color: var(--colors-black);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.link:visited {
+  color: var(--colors-black);
+}
+
+.share {
+  opacity: 0;
+  transition: opacity .3s;
+}
+
+.container:hover .link .share {
+  opacity: 1;
+}

--- a/website2/src/components/documentationPage/documentHeader/styles.module.css
+++ b/website2/src/components/documentationPage/documentHeader/styles.module.css
@@ -12,8 +12,22 @@
 .share {
   opacity: 0;
   transition: opacity .3s;
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
 }
 
 .container:hover .link .share {
   opacity: 1;
+}
+
+@media only screen and (max-width: 768px) {
+  .link {
+    justify-content: space-between;
+  }
+
+  .share {
+    opacity: 1;
+    color: var(--color-gray88)
+  }
 }

--- a/website2/src/components/icons/share.tsx
+++ b/website2/src/components/icons/share.tsx
@@ -2,19 +2,19 @@ import { SVGProps } from "react";
 
 export const Share = (props: SVGProps<SVGSVGElement>) => (
   <svg viewBox="0 0 16 16" height="0.7em" width="0.7em" {...props}>
-    <g stroke-width="1.2" fill="none" stroke="currentColor">
+    <g strokeWidth="1.2" fill="none" stroke="currentColor">
       <path
         fill="none"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-miterlimit="10"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeMiterlimit="10"
         d="M8.995,7.005 L8.995,7.005c1.374,1.374,1.374,3.601,0,4.975l-1.99,1.99c-1.374,1.374-3.601,1.374-4.975,0l0,0c-1.374-1.374-1.374-3.601,0-4.975 l1.748-1.698"
       ></path>
       <path
         fill="none"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-miterlimit="10"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeMiterlimit="10"
         d="M7.005,8.995 L7.005,8.995c-1.374-1.374-1.374-3.601,0-4.975l1.99-1.99c1.374-1.374,3.601-1.374,4.975,0l0,0c1.374,1.374,1.374,3.601,0,4.975 l-1.748,1.698"
       ></path>
     </g>

--- a/website2/src/components/icons/share.tsx
+++ b/website2/src/components/icons/share.tsx
@@ -1,0 +1,22 @@
+import { SVGProps } from "react";
+
+export const Share = (props: SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 16 16" height="0.7em" width="0.7em" {...props}>
+    <g stroke-width="1.2" fill="none" stroke="currentColor">
+      <path
+        fill="none"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-miterlimit="10"
+        d="M8.995,7.005 L8.995,7.005c1.374,1.374,1.374,3.601,0,4.975l-1.99,1.99c-1.374,1.374-3.601,1.374-4.975,0l0,0c-1.374-1.374-1.374-3.601,0-4.975 l1.748-1.698"
+      ></path>
+      <path
+        fill="none"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-miterlimit="10"
+        d="M7.005,8.995 L7.005,8.995c-1.374-1.374-1.374-3.601,0-4.975l1.99-1.99c1.374-1.374,3.601-1.374,4.975,0l0,0c1.374,1.374,1.374,3.601,0,4.975 l-1.748,1.698"
+      ></path>
+    </g>
+  </svg>
+);


### PR DESCRIPTION
adds anchor tags and ids to headers in the documentation

![anchor](https://github.com/garnix-io/garn/assets/8580080/1333f469-1f39-49e1-ac44-933bb2bf8540)
<img width="333" alt="Screenshot 2023-12-13 at 2 13 59 PM" src="https://github.com/garnix-io/garn/assets/8580080/42be5640-a894-4412-af84-bb61356592ab">
