### PR TITLE
Fix horizontal overflow for SampleCode component

### DIFF
--- a/website2/src/app/docs/[slug]/page.tsx
+++ b/website2/src/app/docs/[slug]/page.tsx
@@ -16,7 +16,7 @@ const Page = async ({ params: { slug } }: { params: { slug: string } }) => {
       <DocumentationHeader links={links} active={slug} />
       <div className={styles.layout}>
         <Sidebar links={links} active={slug} />
-        <Document source={source} />
+        <Document className={styles.document} source={source} />
       </div>
       <Footer />
     </main>

--- a/website2/src/app/docs/[slug]/styles.module.css
+++ b/website2/src/app/docs/[slug]/styles.module.css
@@ -7,6 +7,10 @@
   border-right: 16px solid var(--color-black);
 }
 
+.document {
+  min-width: 0;
+}
+
 @media only screen and (max-width: 768px) {
   .layout {
     display: block;

--- a/website2/src/components/documentationPage/document/index.tsx
+++ b/website2/src/components/documentationPage/document/index.tsx
@@ -9,11 +9,12 @@ import { DocumentHeader } from "../documentHeader";
 
 type Props = {
   source: string;
+  className?: string;
 };
 
-export const Document = ({ source }: Props) => {
+export const Document = ({ source, className }: Props) => {
   return (
-    <section>
+    <section className={className}>
       <MDXRemote
         source={source}
         options={{ parseFrontmatter: true }}

--- a/website2/src/components/sampleCode.tsx
+++ b/website2/src/components/sampleCode.tsx
@@ -23,6 +23,7 @@ export const SampleCode = ({ code, inverse, language }: Props) => {
         textShadow: "none",
       }}
       codeTagProps={{ style: { background: "transparent" } }}
+      wrapLongLines
     >
       {code}
     </SyntaxHighlighter>

--- a/website2/src/components/sampleCode.tsx
+++ b/website2/src/components/sampleCode.tsx
@@ -18,7 +18,6 @@ export const SampleCode = ({ code, inverse, language }: Props) => {
       customStyle={{
         background: "transparent",
         padding: 0,
-        paddingBottom: 8,
         margin: 0,
         textShadow: "none",
       }}

--- a/website2/src/components/sampleCode.tsx
+++ b/website2/src/components/sampleCode.tsx
@@ -22,7 +22,6 @@ export const SampleCode = ({ code, inverse, language }: Props) => {
         textShadow: "none",
       }}
       codeTagProps={{ style: { background: "transparent" } }}
-      wrapLongLines
     >
       {code}
     </SyntaxHighlighter>


### PR DESCRIPTION
fixes issue [#687](https://github.com/garnix-io/garnix/issues/687)

- not the most elegant fix, but prevents the horizontal overflow. We could consider making the code in the box smaller incrementally with less horizontal screen space to prevent line wrapping, but that's not a perfect solution either
- also removes some extra padding at the bottom of SampleCode

![Screenshot 2024-01-16 at 2 43 21 PM](https://github.com/garnix-io/garn/assets/8580080/6f872227-e9d0-4bc2-9712-6dd47db716a5)
